### PR TITLE
Implement public booking widget and pending booking flow

### DIFF
--- a/app/(public)/[handle]/page.tsx
+++ b/app/(public)/[handle]/page.tsx
@@ -1,9 +1,7 @@
 import { notFound } from "next/navigation";
 import { getPublicClient } from "@/lib/supabase/server";
 import type { ProviderProfile, Service, AvailabilityRule, BlackoutDate } from "@/lib/domain/types";
-import { generateBookableSlots } from "@/lib/domain/availability";
-import { ServiceList } from "@/components/service-list";
-import { AvailabilitySlotPicker } from "@/components/availability-slot-picker";
+import { PublicBookingWidget } from "@/components/public-booking-widget";
 
 interface ProviderPageData {
   provider: ProviderProfile;
@@ -121,16 +119,6 @@ export default async function ProviderPage({ params }: ProviderPageProps) {
     notFound();
   }
 
-  const primaryService = data.services[0];
-  const slots = primaryService
-    ? generateBookableSlots({
-        rules: data.availability,
-        blackoutDates: data.blackoutDates,
-        serviceDurationMin: primaryService.durationMin,
-        days: 14,
-      })
-    : [];
-
   return (
     <div className="space-y-8">
       <header className="space-y-4">
@@ -138,18 +126,13 @@ export default async function ProviderPage({ params }: ProviderPageProps) {
         {data.provider.bio ? <p className="text-slate-300">{data.provider.bio}</p> : null}
       </header>
 
-      <section className="grid gap-6 lg:grid-cols-5">
-        <div className="space-y-4 lg:col-span-3">
-          <h2 className="text-xl font-semibold text-white">Services</h2>
-          <ServiceList services={data.services} currency={data.provider.currency} />
-        </div>
-        <div className="space-y-4 lg:col-span-2">
-          <h2 className="text-xl font-semibold text-white">Available Slots</h2>
-          <AvailabilitySlotPicker slots={slots} />
-          <p className="text-xs text-slate-400">
-            After you request a slot we’ll send confirmation by email and WhatsApp once your provider approves the booking.
-          </p>
-        </div>
+      <section className="rounded-xl border border-slate-800 bg-slate-950/60 p-6 shadow-lg shadow-black/20">
+        <PublicBookingWidget
+          provider={data.provider}
+          services={data.services}
+          availability={data.availability}
+          blackoutDates={data.blackoutDates}
+        />
       </section>
     </div>
   );

--- a/app/api/payments/webhook/route.ts
+++ b/app/api/payments/webhook/route.ts
@@ -32,9 +32,6 @@ export async function POST(request: NextRequest) {
   let payload: Json;
   try {
     payload = JSON.parse(rawBody) as Json;
-  let payload: unknown;
-  try {
-    payload = JSON.parse(rawBody);
   } catch (error) {
     console.error("Unable to parse webhook payload", error);
     return NextResponse.json({ error: "Invalid payload" }, { status: 400 });

--- a/app/api/public/booking/check/route.ts
+++ b/app/api/public/booking/check/route.ts
@@ -1,0 +1,138 @@
+import { addDays } from "date-fns";
+import { NextResponse, type NextRequest } from "next/server";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+import { checkAvailabilitySchema } from "@/lib/validation/booking";
+import { filterSlotsByBookings, generateBookableSlots } from "@/lib/domain/availability";
+import type { BookingStatus } from "@/lib/domain/types";
+
+interface BookingRow {
+  start_at: string;
+  end_at: string;
+  status: string;
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const parsed = checkAvailabilitySchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  let supabase;
+  try {
+    supabase = getServiceRoleClient();
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Server misconfigured" }, { status: 500 });
+  }
+
+  const { providerHandle, serviceId, date } = parsed.data;
+
+  const { data: provider, error: providerError } = await supabase
+    .from("providers")
+    .select("id, handle")
+    .eq("handle", providerHandle)
+    .maybeSingle();
+
+  if (providerError) {
+    console.error(providerError);
+    return NextResponse.json({ error: "Unable to load provider" }, { status: 500 });
+  }
+
+  if (!provider) {
+    return NextResponse.json({ error: "Provider not found" }, { status: 404 });
+  }
+
+  const { data: service, error: serviceError } = await supabase
+    .from("services")
+    .select("id, provider_id, duration_min, is_active")
+    .eq("id", serviceId)
+    .maybeSingle();
+
+  if (serviceError) {
+    console.error(serviceError);
+    return NextResponse.json({ error: "Unable to load service" }, { status: 500 });
+  }
+
+  if (!service || service.provider_id !== provider.id || !service.is_active) {
+    return NextResponse.json({ error: "Service not available" }, { status: 404 });
+  }
+
+  const { data: rules, error: rulesError } = await supabase
+    .from("availability_rules")
+    .select("id, provider_id, dow, start_time, end_time")
+    .eq("provider_id", provider.id);
+
+  if (rulesError) {
+    console.error(rulesError);
+    return NextResponse.json({ error: "Unable to load availability" }, { status: 500 });
+  }
+
+  const { data: blackoutDates, error: blackoutError } = await supabase
+    .from("blackout_dates")
+    .select("id, provider_id, day, reason")
+    .eq("provider_id", provider.id)
+    .gte("day", date)
+    .lte("day", date);
+
+  if (blackoutError) {
+    console.error(blackoutError);
+    return NextResponse.json({ error: "Unable to load blackout dates" }, { status: 500 });
+  }
+
+  if (!rules || rules.length === 0) {
+    return NextResponse.json({ slots: [] });
+  }
+
+  const dayStart = new Date(`${date}T00:00:00.000Z`);
+  const dayEnd = addDays(dayStart, 1);
+
+  const baseSlots = generateBookableSlots({
+    rules: rules.map((rule) => ({
+      id: rule.id,
+      providerId: rule.provider_id,
+      dow: rule.dow,
+      startTime: rule.start_time,
+      endTime: rule.end_time,
+    })),
+    blackoutDates: (blackoutDates ?? []).map((entry) => ({
+      id: entry.id,
+      providerId: entry.provider_id,
+      day: entry.day,
+      reason: entry.reason,
+    })),
+    serviceDurationMin: service.duration_min,
+    from: dayStart.toISOString(),
+    days: 1,
+  }).filter((slot) => slot.start.startsWith(date));
+
+  if (baseSlots.length === 0) {
+    return NextResponse.json({ slots: [] });
+  }
+
+  const { data: bookings, error: bookingsError } = await supabase
+    .from("bookings")
+    .select("start_at, end_at, status")
+    .eq("provider_id", provider.id)
+    .eq("service_id", service.id)
+    .in("status", ["pending", "confirmed"])
+    .gte("start_at", dayStart.toISOString())
+    .lt("start_at", dayEnd.toISOString());
+
+  if (bookingsError) {
+    console.error(bookingsError);
+    return NextResponse.json({ error: "Unable to load bookings" }, { status: 500 });
+  }
+
+  const availableSlots = filterSlotsByBookings({
+    slots: baseSlots,
+    bookings: (bookings as BookingRow[] | null)?.map((booking) => ({
+      startAt: booking.start_at,
+      endAt: booking.end_at,
+      status: booking.status as BookingStatus,
+    })) ?? [],
+  });
+
+  return NextResponse.json({ slots: availableSlots });
+}

--- a/app/api/public/booking/create/route.ts
+++ b/app/api/public/booking/create/route.ts
@@ -1,7 +1,14 @@
-import { addMinutes } from "date-fns";
+import { addDays, isBefore } from "date-fns";
 import { NextResponse, type NextRequest } from "next/server";
 import { getServiceRoleClient } from "@/lib/supabase/server";
 import { createBookingSchema } from "@/lib/validation/booking";
+import { filterSlotsByBookings, generateBookableSlots } from "@/lib/domain/availability";
+
+interface BookingWindowRow {
+  start_at: string;
+  end_at: string;
+  status: string;
+}
 
 export async function POST(request: NextRequest) {
   const body = await request.json();
@@ -23,7 +30,7 @@ export async function POST(request: NextRequest) {
 
   const { data: provider, error: providerError } = await supabase
     .from("providers")
-    .select("id, currency, handle")
+    .select("id, currency, handle, display_name")
     .eq("handle", providerHandle)
     .maybeSingle();
 
@@ -38,7 +45,7 @@ export async function POST(request: NextRequest) {
 
   const { data: service, error: serviceError } = await supabase
     .from("services")
-    .select("id, provider_id, duration_min, base_price_cents, is_active")
+    .select("id, provider_id, duration_min, base_price_cents, is_active, name")
     .eq("id", serviceId)
     .maybeSingle();
 
@@ -52,7 +59,97 @@ export async function POST(request: NextRequest) {
   }
 
   const startDate = new Date(startAt);
-  const endDate = addMinutes(startDate, service.duration_min);
+
+  if (Number.isNaN(startDate.getTime())) {
+    return NextResponse.json({ error: "Invalid start time" }, { status: 400 });
+  }
+
+  if (isBefore(startDate, new Date())) {
+    return NextResponse.json({ error: "Selected time is in the past" }, { status: 409 });
+  }
+
+  const { data: rules, error: rulesError } = await supabase
+    .from("availability_rules")
+    .select("id, provider_id, dow, start_time, end_time")
+    .eq("provider_id", provider.id);
+
+  if (rulesError) {
+    console.error(rulesError);
+    return NextResponse.json({ error: "Unable to load availability" }, { status: 500 });
+  }
+
+  if (!rules || rules.length === 0) {
+    return NextResponse.json({ error: "No availability configured" }, { status: 409 });
+  }
+
+  const { data: blackoutDates, error: blackoutError } = await supabase
+    .from("blackout_dates")
+    .select("id, provider_id, day, reason")
+    .eq("provider_id", provider.id);
+
+  if (blackoutError) {
+    console.error(blackoutError);
+    return NextResponse.json({ error: "Unable to load blackout dates" }, { status: 500 });
+  }
+
+  const dayStart = new Date(startDate);
+  dayStart.setUTCHours(0, 0, 0, 0);
+  const dayEnd = addDays(dayStart, 1);
+
+  const baseSlots = generateBookableSlots({
+    rules: rules.map((rule) => ({
+      id: rule.id,
+      providerId: rule.provider_id,
+      dow: rule.dow,
+      startTime: rule.start_time,
+      endTime: rule.end_time,
+    })),
+    blackoutDates: (blackoutDates ?? []).map((entry) => ({
+      id: entry.id,
+      providerId: entry.provider_id,
+      day: entry.day,
+      reason: entry.reason,
+    })),
+    serviceDurationMin: service.duration_min,
+    from: dayStart.toISOString(),
+    days: 1,
+  });
+
+  if (baseSlots.length === 0) {
+    return NextResponse.json({ error: "Selected day has no availability" }, { status: 409 });
+  }
+
+  const { data: bookings, error: bookingsError } = await supabase
+    .from("bookings")
+    .select("start_at, end_at, status")
+    .eq("provider_id", provider.id)
+    .eq("service_id", service.id)
+    .in("status", ["pending", "confirmed"])
+    .gte("start_at", dayStart.toISOString())
+    .lt("start_at", dayEnd.toISOString());
+
+  if (bookingsError) {
+    console.error(bookingsError);
+    return NextResponse.json({ error: "Unable to load bookings" }, { status: 500 });
+  }
+
+  const availableSlots = filterSlotsByBookings({
+    slots: baseSlots,
+    bookings:
+      (bookings as BookingWindowRow[] | null)?.map((booking) => ({
+        startAt: booking.start_at,
+        endAt: booking.end_at,
+        status: booking.status as "pending" | "confirmed",
+      })) ?? [],
+  });
+
+  const requestedSlot = availableSlots.find((slot) => slot.start === startDate.toISOString());
+
+  if (!requestedSlot) {
+    return NextResponse.json({ error: "Slot no longer available" }, { status: 409 });
+  }
+
+  const endDate = new Date(requestedSlot.end);
 
   const { data: customerRow, error: customerError } = await supabase
     .from("customers")
@@ -82,8 +179,8 @@ export async function POST(request: NextRequest) {
       provider_id: provider.id,
       service_id: service.id,
       customer_id: customerRow.id,
-      start_at: startDate.toISOString(),
-      end_at: endDate.toISOString(),
+      start_at: requestedSlot.start,
+      end_at: requestedSlot.end,
       status: "pending",
       notes: notes ?? null,
     })
@@ -95,12 +192,36 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unable to create booking" }, { status: 500 });
   }
 
+  if (!booking) {
+    return NextResponse.json({ error: "Unable to create booking" }, { status: 500 });
+  }
+
+  const { error: notificationError } = await supabase.from("notifications").insert({
+    booking_id: booking.id,
+    channel: "email",
+    recipient: customer.email,
+    payload: {
+      type: "booking_customer_pending",
+      bookingId: booking.id,
+      providerHandle: provider.handle,
+      providerName: provider.display_name ?? provider.handle,
+      serviceName: service.name,
+      startAt: booking.start_at,
+      customerName: customer.name,
+    },
+  });
+
+  if (notificationError) {
+    console.error(notificationError);
+    return NextResponse.json({ error: "Failed to queue notification" }, { status: 500 });
+  }
+
   return NextResponse.json({
     booking: {
-      id: booking?.id,
-      startAt: booking?.start_at,
-      endAt: booking?.end_at,
-      status: booking?.status,
+      id: booking.id,
+      startAt: booking.start_at,
+      endAt: booking.end_at,
+      status: booking.status,
     },
     message: "Booking received. We will confirm shortly via WhatsApp and email.",
   });

--- a/components/public-booking-widget.tsx
+++ b/components/public-booking-widget.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { addDays, format } from "date-fns";
+import { AvailabilitySlotPicker } from "@/components/availability-slot-picker";
+import { ServiceList } from "@/components/service-list";
+import type { AvailabilitySlot } from "@/lib/domain/availability";
+import type { AvailabilityRule, BlackoutDate, ProviderProfile, Service } from "@/lib/domain/types";
+
+interface BookingWidgetProps {
+  provider: ProviderProfile;
+  services: Service[];
+  availability: AvailabilityRule[];
+  blackoutDates: BlackoutDate[];
+}
+
+interface DayOption {
+  label: string;
+  value: string;
+  disabled: boolean;
+}
+
+type SubmissionState =
+  | { status: "idle" | "submitting" }
+  | { status: "success"; message: string }
+  | { status: "error"; message: string };
+
+export function pickFirstOpenDate(availability: AvailabilityRule[], blackoutDates: BlackoutDate[]): string {
+  const blackoutSet = new Set(blackoutDates.map((entry) => entry.day));
+  const availableDow = new Set(availability.map((rule) => rule.dow));
+  const today = new Date();
+
+  for (let index = 0; index < 14; index += 1) {
+    const day = addDays(today, index);
+    const value = format(day, "yyyy-MM-dd");
+    if (!availableDow.has(day.getDay())) {
+      continue;
+    }
+    if (blackoutSet.has(value)) {
+      continue;
+    }
+    return value;
+  }
+
+  return format(today, "yyyy-MM-dd");
+}
+
+export function PublicBookingWidget({ provider, services, availability, blackoutDates }: BookingWidgetProps) {
+  const [selectedServiceId, setSelectedServiceId] = useState<string | null>(services[0]?.id ?? null);
+  const [selectedDate, setSelectedDate] = useState<string>(() => pickFirstOpenDate(availability, blackoutDates));
+  const [slots, setSlots] = useState<AvailabilitySlot[]>([]);
+  const [slotsError, setSlotsError] = useState<string | null>(null);
+  const [loadingSlots, setLoadingSlots] = useState<boolean>(false);
+  const [selectedSlot, setSelectedSlot] = useState<AvailabilitySlot | null>(null);
+  const [customerName, setCustomerName] = useState("");
+  const [customerEmail, setCustomerEmail] = useState("");
+  const [customerPhone, setCustomerPhone] = useState("");
+  const [notes, setNotes] = useState("");
+  const [submission, setSubmission] = useState<SubmissionState>({ status: "idle" });
+
+  const dayOptions = useMemo<DayOption[]>(() => {
+    const blackoutSet = new Set(blackoutDates.map((entry) => entry.day));
+    const availableDow = new Set(availability.map((rule) => rule.dow));
+
+    return Array.from({ length: 14 }, (_, index) => {
+      const day = addDays(new Date(), index);
+      const value = format(day, "yyyy-MM-dd");
+      const disabled = blackoutSet.has(value) || !availableDow.has(day.getDay());
+      return {
+        value,
+        label: format(day, "EEE MMM d"),
+        disabled,
+      };
+    });
+  }, [availability, blackoutDates]);
+
+  const selectedService = useMemo(() => services.find((service) => service.id === selectedServiceId) ?? null, [
+    services,
+    selectedServiceId,
+  ]);
+
+  useEffect(() => {
+    if (!selectedService) {
+      setSlots([]);
+      setSelectedSlot(null);
+      return;
+    }
+
+    const serviceId = selectedService.id;
+
+    let isCancelled = false;
+    async function fetchSlots() {
+      setLoadingSlots(true);
+      setSlotsError(null);
+      setSelectedSlot(null);
+
+      try {
+        const response = await fetch("/api/public/booking/check", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            providerHandle: provider.handle,
+            serviceId,
+            date: selectedDate,
+          }),
+        });
+
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({ error: "Unable to load availability" }));
+          throw new Error(body.error ?? "Unable to load availability");
+        }
+
+        const data = (await response.json()) as { slots: AvailabilitySlot[] };
+        if (!isCancelled) {
+          setSlots(data.slots);
+        }
+      } catch (error) {
+        if (!isCancelled) {
+          setSlots([]);
+          setSlotsError(error instanceof Error ? error.message : "Unable to load availability");
+        }
+      } finally {
+        if (!isCancelled) {
+          setLoadingSlots(false);
+        }
+      }
+    }
+
+    fetchSlots();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [provider.handle, selectedDate, selectedService]);
+
+  const isSubmitDisabled =
+    !selectedService ||
+    !selectedSlot ||
+    !customerName.trim() ||
+    !customerEmail.trim() ||
+    !customerPhone.trim() ||
+    submission.status === "submitting";
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selectedService || !selectedSlot) {
+      setSubmission({ status: "error", message: "Select a service and time" });
+      return;
+    }
+
+    setSubmission({ status: "submitting" });
+
+    const serviceId = selectedService.id;
+    const slotStart = selectedSlot.start;
+
+    try {
+      const response = await fetch("/api/public/booking/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          providerHandle: provider.handle,
+          serviceId,
+          startAt: slotStart,
+          customer: {
+            name: customerName,
+            email: customerEmail,
+            phone: customerPhone,
+          },
+          notes: notes.trim() ? notes.trim() : undefined,
+        }),
+      });
+
+      const body = await response.json().catch(() => ({ error: "Unable to place booking" }));
+
+      if (!response.ok) {
+        throw new Error(body.error ?? "Unable to place booking");
+      }
+
+      setSubmission({ status: "success", message: body.message ?? "Booking request received" });
+      setSlots((current) => current.filter((slot) => slot.start !== slotStart));
+      setSelectedSlot(null);
+    } catch (error) {
+      setSubmission({ status: "error", message: error instanceof Error ? error.message : "Unable to place booking" });
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-white">Services</h2>
+        <ServiceList
+          services={services}
+          currency={provider.currency}
+          onSelect={(service) => setSelectedServiceId(service.id)}
+          selectedServiceId={selectedServiceId ?? undefined}
+        />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-white">Pick a day</h2>
+        <div className="flex flex-wrap gap-2">
+          {dayOptions.map((option) => {
+            const isSelected = option.value === selectedDate;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setSelectedDate(option.value)}
+                disabled={option.disabled}
+                className={`rounded-full border px-3 py-1 text-sm transition ${
+                  option.disabled
+                    ? "cursor-not-allowed border-slate-800 bg-slate-900 text-slate-500"
+                    : isSelected
+                      ? "border-accent bg-accent/20 text-white"
+                      : "border-slate-700 bg-slate-900 hover:border-accent/60"
+                }`}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold text-white">Available slots</h2>
+        {slotsError ? <p className="text-sm text-red-400">{slotsError}</p> : null}
+        {loadingSlots ? <p className="text-sm text-slate-400">Loading availability…</p> : null}
+        {!loadingSlots && !slotsError ? (
+          <AvailabilitySlotPicker
+            slots={slots}
+            onSelect={(slot) => setSelectedSlot(slot)}
+          />
+        ) : null}
+        {selectedService ? (
+          <p className="text-xs text-slate-400">
+            Each {selectedService.name.toLowerCase()} runs {selectedService.durationMin} minutes. We&apos;ll confirm via email and
+            WhatsApp once your provider approves.
+          </p>
+        ) : null}
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-white">Your details</h2>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="flex flex-col gap-1 text-sm text-slate-200">
+              Full name
+              <input
+                required
+                value={customerName}
+                onChange={(event) => setCustomerName(event.target.value)}
+                className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-white focus:border-accent focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm text-slate-200">
+              Email
+              <input
+                type="email"
+                required
+                value={customerEmail}
+                onChange={(event) => setCustomerEmail(event.target.value)}
+                className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-white focus:border-accent focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm text-slate-200">
+              Phone (WhatsApp)
+              <input
+                required
+                value={customerPhone}
+                onChange={(event) => setCustomerPhone(event.target.value)}
+                className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-white focus:border-accent focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm text-slate-200">
+              Notes (optional)
+              <textarea
+                value={notes}
+                onChange={(event) => setNotes(event.target.value)}
+                rows={3}
+                className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-white focus:border-accent focus:outline-none"
+              />
+            </label>
+          </div>
+          <div className="space-y-2">
+            <button
+              type="submit"
+              disabled={isSubmitDisabled}
+              className="w-full rounded-md bg-accent px-4 py-2 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:bg-slate-700"
+            >
+              {submission.status === "submitting" ? "Sending request…" : "Request booking"}
+            </button>
+            {submission.status === "error" ? (
+              <p className="text-sm text-red-400">{submission.message}</p>
+            ) : null}
+            {submission.status === "success" ? (
+              <p className="text-sm text-emerald-400">{submission.message}</p>
+            ) : null}
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/lib/domain/payments.ts
+++ b/lib/domain/payments.ts
@@ -4,7 +4,6 @@ export interface PaymentGateway {
     bookingId: string,
     amountCents: number,
   ): Promise<{ checkoutUrl: string; reference: string }>;
-  createPerBookingIntent(bookingId: string, amountCents: number): Promise<{ checkoutUrl: string }>;
   verifyWebhook(sig: string, rawBody: string): boolean;
   parseEvent(rawBody: string): { type: "payment.succeeded" | "payment.failed"; refId: string };
 }
@@ -13,6 +12,7 @@ export class MockPaymentGateway implements PaymentGateway {
   async createTopupIntent(providerId: string, credits: number): Promise<{ checkoutUrl: string }> {
     return { checkoutUrl: `https://mockpay.local/topup?provider=${providerId}&credits=${credits}` };
   }
+
   async createPerBookingIntent(
     bookingId: string,
     amountCents: number,
@@ -25,13 +25,6 @@ export class MockPaymentGateway implements PaymentGateway {
   }
 
   verifyWebhook(_sig: string, _rawBody: string): boolean {
-    
-  async createPerBookingIntent(bookingId: string, amountCents: number): Promise<{ checkoutUrl: string }> {
-    return { checkoutUrl: `https://mockpay.local/booking/${bookingId}?amount=${amountCents}` };
-  }
-
-  verifyWebhook(): boolean {
-  
     return true;
   }
 

--- a/lib/domain/wallet.ts
+++ b/lib/domain/wallet.ts
@@ -20,7 +20,6 @@ export interface PaymentIntentProvider {
     bookingId: string,
     amountCents: number,
   ): Promise<{ checkoutUrl: string; reference: string }>;
-  createPerBookingIntent(bookingId: string, amountCents: number): Promise<{ checkoutUrl: string }>;
 }
 
 export function consumeCreditForBooking(wallet: Wallet, booking: Booking, now: Date = new Date()): CreditConsumptionResult {
@@ -55,10 +54,6 @@ export async function confirmBookingHappyPath(params: {
 
   if (wallet.balanceCredits < 1) {
     const paymentIntent = await paymentIntentProvider.createPerBookingIntent(booking.id, bookingAmountCents);
-    const paymentIntent = await paymentIntentProvider.createPerBookingIntent(
-      booking.id,
-      bookingAmountCents,
-    );
 
     return {
       status: "requires_payment",

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -41,6 +41,8 @@ export function getPublicServerClient(): SupabaseClient<Database> {
   });
 }
 
+export const getPublicClient = getPublicServerClient;
+
 /**
  * Server client (RSC/Route Handlers) with cookie bridging.
  * Use this for authenticated server reads/writes with the user's session.

--- a/lib/validation/booking.ts
+++ b/lib/validation/booking.ts
@@ -20,3 +20,11 @@ export const confirmBookingSchema = z.object({
 });
 
 export type ConfirmBookingInput = z.infer<typeof confirmBookingSchema>;
+
+export const checkAvailabilitySchema = z.object({
+  providerHandle: z.string().min(2),
+  serviceId: z.string().uuid(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
+export type CheckAvailabilityInput = z.infer<typeof checkAvailabilitySchema>;

--- a/tests/public-booking-widget.test.ts
+++ b/tests/public-booking-widget.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { pickFirstOpenDate } from "@/components/public-booking-widget";
+import type { AvailabilityRule, BlackoutDate } from "@/lib/domain/types";
+
+const baseRules: AvailabilityRule[] = [
+  { id: "r1", providerId: "p1", dow: 2, startTime: "09:00", endTime: "17:00" },
+  { id: "r2", providerId: "p1", dow: 3, startTime: "09:00", endTime: "17:00" },
+];
+
+const baseBlackouts: BlackoutDate[] = [];
+
+describe("pickFirstOpenDate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("selects the next day with availability when the first is blacked out", () => {
+    const blackoutDates: BlackoutDate[] = [{ id: "b1", providerId: "p1", day: "2024-01-02", reason: "Holiday" }];
+
+    const result = pickFirstOpenDate(baseRules, blackoutDates);
+
+    expect(result).toBe("2024-01-03");
+  });
+
+  it("falls back to today if no matching availability exists", () => {
+    const closedRules: AvailabilityRule[] = [
+      { id: "r3", providerId: "p1", dow: 0, startTime: "09:00", endTime: "17:00" },
+    ];
+
+    const result = pickFirstOpenDate(closedRules, baseBlackouts);
+
+    expect(result).toBe("2024-01-01");
+  });
+});

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -46,7 +46,6 @@ describe("confirmBookingHappyPath", () => {
       booking: baseBooking,
       paymentIntentProvider: {
         createPerBookingIntent: vi.fn().mockResolvedValue({ checkoutUrl: "", reference: "" }),
-        createPerBookingIntent: vi.fn(),
       },
       bookingAmountCents: 5000,
     });
@@ -61,7 +60,6 @@ describe("confirmBookingHappyPath", () => {
       createPerBookingIntent: vi
         .fn()
         .mockResolvedValue({ checkoutUrl: "https://mockpay.local/checkout", reference: "mockpay_booking-1" }),
-      createPerBookingIntent: vi.fn().mockResolvedValue({ checkoutUrl: "https://mockpay.local/checkout" }),
     };
 
     const result = await confirmBookingHappyPath({


### PR DESCRIPTION
## Summary
- replace the public provider page content with an interactive booking widget that walks customers through service, date, and contact selection
- harden the public booking create API to validate requested slots against availability and queue a pending confirmation email notification
- cover the booking widget's date picker logic with unit tests to ensure blackout days and closed schedules are skipped

## Testing
- npm run lint
- npm run typecheck
- npm run test *(fails: npm optional dependency bug prevents installing `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_68d42db403a88326b9b2bdc2e6fd30cd