### PR TITLE
Add provider dashboard reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 .env.local
 .env*
 !.env.example
+tsconfig.tsbuildinfo
 *.log
 supabase/.branches
 .supabase

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,0 +1,149 @@
+import { redirect } from "next/navigation";
+import { format } from "date-fns";
+import { getServerComponentClient } from "@/lib/supabase/server";
+import {
+  fetchProviderDashboardSummary,
+  fetchUpcomingBookings,
+} from "@/lib/domain/reporting";
+
+function MetricCard({
+  label,
+  value,
+  helper,
+}: {
+  label: string;
+  value: number | string;
+  helper?: string;
+}) {
+  const displayValue =
+    typeof value === "number" ? value.toLocaleString("en-US") : value;
+
+  return (
+    <article className="card space-y-2">
+      <p className="text-sm uppercase tracking-wide text-slate-400">{label}</p>
+      <p className="text-3xl font-semibold text-white">{displayValue}</p>
+      {helper ? <p className="text-xs text-slate-400">{helper}</p> : null}
+    </article>
+  );
+}
+
+export default async function DashboardPage() {
+  const supabase = getServerComponentClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login?next=/dashboard");
+  }
+
+  const { data: provider, error: providerError } = await supabase
+    .from("providers")
+    .select("id, display_name")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (providerError) {
+    console.error(providerError);
+    throw new Error("Unable to load provider profile");
+  }
+
+  if (!provider) {
+    redirect("/onboarding");
+  }
+
+  const [summary, upcomingBookings] = await Promise.all([
+    fetchProviderDashboardSummary(supabase, provider.id),
+    fetchUpcomingBookings(supabase, provider.id),
+  ]);
+
+  const metrics = [
+    {
+      label: "Upcoming confirmed",
+      value: summary.upcomingConfirmed,
+      helper: "Future confirmed bookings",
+    },
+    {
+      label: "Today",
+      value: summary.todayConfirmed,
+      helper: "Confirmed bookings happening today",
+    },
+    {
+      label: "This week",
+      value: summary.weekConfirmed,
+      helper: "Confirmed bookings scheduled this week",
+    },
+    {
+      label: "Pending approval",
+      value: summary.pendingCount,
+      helper: "Bookings waiting on your confirmation",
+    },
+  ];
+
+  return (
+    <div className="space-y-10">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold text-white">Dashboard overview</h1>
+        <p className="text-sm text-slate-400">
+          Welcome back{provider.display_name ? `, ${provider.display_name}` : ""}. Here’s the current pulse of your
+          bookings.
+        </p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {metrics.map((metric) => (
+          <MetricCard key={metric.label} {...metric} />
+        ))}
+      </section>
+
+      <section className="card space-y-3">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-white">Conversion health</h2>
+            <p className="text-sm text-slate-400">
+              {summary.recentConversion.confirmed} of {summary.recentConversion.total} bookings created in the last {" "}
+              {summary.recentConversion.windowDays} days were confirmed.
+            </p>
+          </div>
+          <span className="text-3xl font-semibold text-white">
+            {summary.recentConversion.ratePercent.toFixed(1)}%
+          </span>
+        </div>
+        <p className="text-xs text-slate-500">
+          Keep following up on pending bookings to lift your conversion rate.
+        </p>
+      </section>
+
+      <section className="card space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-white">Next up</h2>
+          <span className="text-xs uppercase tracking-wide text-slate-500">Next 5 confirmed bookings</span>
+        </div>
+        {upcomingBookings.length === 0 ? (
+          <p className="text-sm text-slate-400">No confirmed bookings on the horizon yet. Share your link to fill the calendar.</p>
+        ) : (
+          <ul className="space-y-3">
+            {upcomingBookings.map((booking) => (
+              <li
+                key={booking.id}
+                className="flex flex-col gap-2 rounded-lg border border-slate-800 bg-slate-950/60 p-4 md:flex-row md:items-center md:justify-between"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-white">
+                    {booking.serviceName}
+                    {booking.serviceDurationMin != null ? ` · ${booking.serviceDurationMin} min` : ""}
+                  </p>
+                  <p className="text-xs text-slate-400">{booking.customerName}</p>
+                  {booking.customerPhone ? (
+                    <p className="text-xs text-slate-500">{booking.customerPhone}</p>
+                  ) : null}
+                </div>
+                <p className="text-sm font-medium text-accent">{format(new Date(booking.startAt), "EEE, MMM d • h:mma")}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/api/booking/cancel/route.ts
+++ b/app/api/booking/cancel/route.ts
@@ -1,0 +1,280 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getRouteHandlerClient, getServiceRoleClient } from "@/lib/supabase/server";
+import { cancelBookingSchema } from "@/lib/validation/booking";
+import { evaluateCancellationPolicy } from "@/lib/domain/booking-policy";
+import { refundCreditForCancellation } from "@/lib/domain/wallet";
+import type { Booking } from "@/lib/domain/types";
+import type { Database } from "@/types/database";
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const parsed = cancelBookingSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { bookingId, providerId, reason, cancelledBy } = parsed.data;
+  const actor = cancelledBy ?? "provider";
+
+  const authClient = getRouteHandlerClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await authClient.auth.getUser();
+
+  if (authError) {
+    console.error(authError);
+    return NextResponse.json({ error: "AUTH_ERROR" }, { status: 500 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  }
+
+  const { data: provider, error: providerError } = await authClient
+    .from("providers")
+    .select("id, late_cancel_hours, display_name")
+    .eq("id", providerId)
+    .maybeSingle();
+
+  if (providerError) {
+    console.error(providerError);
+    return NextResponse.json({ error: "PROVIDER_LOOKUP_FAILED" }, { status: 500 });
+  }
+
+  if (!provider) {
+    return NextResponse.json({ error: "PROVIDER_NOT_FOUND" }, { status: 404 });
+  }
+
+  let supabase;
+  try {
+    supabase = getServiceRoleClient();
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Server misconfigured" }, { status: 500 });
+  }
+
+  const { data: booking, error: bookingError } = await supabase
+    .from("bookings")
+    .select("id, provider_id, service_id, customer_id, status, pay_mode, start_at, end_at, notes")
+    .eq("id", bookingId)
+    .maybeSingle();
+
+  if (bookingError) {
+    console.error(bookingError);
+    return NextResponse.json({ error: "Unable to load booking" }, { status: 500 });
+  }
+
+  if (!booking || booking.provider_id !== providerId) {
+    return NextResponse.json({ error: "BOOKING_NOT_FOUND" }, { status: 404 });
+  }
+
+  const { data: service, error: serviceError } = await supabase
+    .from("services")
+    .select("id, name")
+    .eq("id", booking.service_id)
+    .maybeSingle();
+
+  if (serviceError) {
+    console.error(serviceError);
+    return NextResponse.json({ error: "Unable to load service" }, { status: 500 });
+  }
+
+  if (!["pending", "confirmed"].includes(booking.status)) {
+    return NextResponse.json({ error: "UNSUPPORTED_STATUS" }, { status: 409 });
+  }
+
+  const now = new Date();
+  const policy = evaluateCancellationPolicy({
+    bookingStartAt: booking.start_at,
+    lateCancelHours: provider.late_cancel_hours ?? 0,
+    now,
+  });
+
+  let refundIssued = false;
+
+  if (booking.status === "confirmed" && booking.pay_mode === "credit" && policy.refundEligible) {
+    const { data: wallet, error: walletError } = await supabase
+      .from("wallets")
+      .select("id, provider_id, balance_credits, currency")
+      .eq("provider_id", providerId)
+      .maybeSingle();
+
+    if (walletError) {
+      console.error(walletError);
+      return NextResponse.json({ error: "Wallet lookup failed" }, { status: 500 });
+    }
+
+    if (!wallet) {
+      return NextResponse.json({ error: "Wallet missing" }, { status: 400 });
+    }
+
+    const bookingDomain: Booking = {
+      id: booking.id,
+      providerId: booking.provider_id,
+      serviceId: booking.service_id,
+      customerId: booking.customer_id,
+      startAt: booking.start_at,
+      endAt: booking.end_at ?? booking.start_at,
+      status: booking.status as Booking["status"],
+      payMode: booking.pay_mode as Booking["payMode"],
+    };
+
+    const { wallet: updatedWallet, ledgerEntry } = refundCreditForCancellation(
+      {
+        id: wallet.id,
+        providerId: wallet.provider_id,
+        balanceCredits: wallet.balance_credits,
+        currency: wallet.currency,
+      },
+      bookingDomain,
+      now,
+    );
+
+    const { error: walletUpdateError } = await supabase
+      .from("wallets")
+      .update({ balance_credits: updatedWallet.balanceCredits })
+      .eq("id", wallet.id);
+
+    if (walletUpdateError) {
+      console.error(walletUpdateError);
+      return NextResponse.json({ error: "Failed to refund wallet" }, { status: 500 });
+    }
+
+    const { error: ledgerError } = await supabase.from("wallet_ledger").insert({
+      wallet_id: wallet.id,
+      booking_id: booking.id,
+      change_credits: ledgerEntry.changeCredits,
+      description: ledgerEntry.description,
+    });
+
+    if (ledgerError) {
+      console.error(ledgerError);
+      return NextResponse.json({ error: "Failed to record refund" }, { status: 500 });
+    }
+
+    refundIssued = true;
+  } else if (booking.status === "confirmed" && booking.pay_mode === "per_booking" && policy.refundEligible) {
+    const { data: payment, error: paymentError } = await supabase
+      .from("payments")
+      .select("id, status, metadata")
+      .eq("booking_id", booking.id)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (paymentError) {
+      console.error(paymentError);
+      return NextResponse.json({ error: "Payment lookup failed" }, { status: 500 });
+    }
+
+    if (payment && payment.status !== "refunded") {
+      const metadata =
+        payment.metadata && typeof payment.metadata === "object" && !Array.isArray(payment.metadata)
+          ? { ...payment.metadata }
+          : {};
+
+      metadata.refundReason = `cancelled_by_${actor}`;
+      metadata.refundedAt = now.toISOString();
+
+      const { error: refundError } = await supabase
+        .from("payments")
+        .update({ status: "refunded", metadata })
+        .eq("id", payment.id);
+
+      if (refundError) {
+        console.error(refundError);
+        return NextResponse.json({ error: "Failed to update payment" }, { status: 500 });
+      }
+
+      refundIssued = true;
+    }
+  }
+
+  const updatePayload: { status: "cancelled"; updated_at: string; notes?: string | null } = {
+    status: "cancelled",
+    updated_at: now.toISOString(),
+  };
+
+  if (reason) {
+    const noteSegments = [booking.notes, `Cancellation note (${actor}): ${reason}`].filter((segment): segment is string =>
+      Boolean(segment),
+    );
+    updatePayload.notes = noteSegments.join("\n\n");
+  }
+
+  const { error: updateBookingError } = await supabase
+    .from("bookings")
+    .update(updatePayload)
+    .eq("id", booking.id);
+
+  if (updateBookingError) {
+    console.error(updateBookingError);
+    return NextResponse.json({ error: "Failed to cancel booking" }, { status: 500 });
+  }
+
+  if (booking.customer_id) {
+    const { data: customer, error: customerError } = await supabase
+      .from("customers")
+      .select("email, name, phone")
+      .eq("id", booking.customer_id)
+      .maybeSingle();
+
+    if (customerError) {
+      console.error(customerError);
+      return NextResponse.json({ error: "Unable to load customer" }, { status: 500 });
+    }
+
+    const notifications: Database["public"]["Tables"]["notifications"]["Insert"][] = [];
+
+    if (customer?.email) {
+      notifications.push({
+        booking_id: booking.id,
+        channel: "email",
+        recipient: customer.email,
+        payload: {
+          type: "booking_customer_cancelled",
+          cancelledBy: actor,
+          startAt: booking.start_at,
+          refundIssued,
+          providerName: provider.display_name,
+          serviceName: service?.name ?? "your booking",
+          customerName: customer.name ?? undefined,
+        },
+      });
+    }
+
+    if (customer?.phone) {
+      notifications.push({
+        booking_id: booking.id,
+        channel: "whatsapp",
+        recipient: customer.phone,
+        payload: {
+          type: "booking_customer_cancelled",
+          cancelledBy: actor,
+          startAt: booking.start_at,
+          refundIssued,
+          providerName: provider.display_name,
+          serviceName: service?.name ?? "your booking",
+          customerName: customer.name ?? undefined,
+        },
+      });
+    }
+
+    if (notifications.length > 0) {
+      const { error: notificationError } = await supabase.from("notifications").insert(notifications);
+
+      if (notificationError) {
+        console.error(notificationError);
+        return NextResponse.json({ error: "Failed to queue cancellation notice" }, { status: 500 });
+      }
+    }
+  }
+
+  return NextResponse.json({
+    status: "cancelled",
+    refundIssued,
+    lateCancellation: policy.isLate,
+  });
+}

--- a/app/api/booking/reschedule/route.ts
+++ b/app/api/booking/reschedule/route.ts
@@ -1,0 +1,285 @@
+import { addDays, isBefore, startOfDay } from "date-fns";
+import { NextResponse, type NextRequest } from "next/server";
+import { getRouteHandlerClient, getServiceRoleClient } from "@/lib/supabase/server";
+import { rescheduleBookingSchema } from "@/lib/validation/booking";
+import { filterSlotsByBookings, generateBookableSlots } from "@/lib/domain/availability";
+import type { Database } from "@/types/database";
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const parsed = rescheduleBookingSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { bookingId, providerId, newStartAt, chargeCustomerFee, note } = parsed.data;
+  const authClient = getRouteHandlerClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await authClient.auth.getUser();
+
+  if (authError) {
+    console.error(authError);
+    return NextResponse.json({ error: "AUTH_ERROR" }, { status: 500 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  }
+
+  const { data: provider, error: providerError } = await authClient
+    .from("providers")
+    .select("id, reschedule_fee_cents, currency, display_name")
+    .eq("id", providerId)
+    .maybeSingle();
+
+  if (providerError) {
+    console.error(providerError);
+    return NextResponse.json({ error: "PROVIDER_LOOKUP_FAILED" }, { status: 500 });
+  }
+
+  if (!provider) {
+    return NextResponse.json({ error: "PROVIDER_NOT_FOUND" }, { status: 404 });
+  }
+
+  let supabase;
+  try {
+    supabase = getServiceRoleClient();
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Server misconfigured" }, { status: 500 });
+  }
+
+  const { data: booking, error: bookingError } = await supabase
+    .from("bookings")
+    .select("id, provider_id, service_id, customer_id, status, start_at, end_at, notes")
+    .eq("id", bookingId)
+    .maybeSingle();
+
+  if (bookingError) {
+    console.error(bookingError);
+    return NextResponse.json({ error: "Unable to load booking" }, { status: 500 });
+  }
+
+  if (!booking || booking.provider_id !== providerId) {
+    return NextResponse.json({ error: "BOOKING_NOT_FOUND" }, { status: 404 });
+  }
+
+  if (!["pending", "confirmed"].includes(booking.status)) {
+    return NextResponse.json({ error: "UNSUPPORTED_STATUS" }, { status: 409 });
+  }
+
+  const nextStart = new Date(newStartAt);
+  if (Number.isNaN(nextStart.getTime())) {
+    return NextResponse.json({ error: "INVALID_START" }, { status: 400 });
+  }
+
+  if (isBefore(nextStart, new Date())) {
+    return NextResponse.json({ error: "START_IN_PAST" }, { status: 409 });
+  }
+
+  const { data: service, error: serviceError } = await supabase
+    .from("services")
+    .select("id, provider_id, duration_min, name")
+    .eq("id", booking.service_id)
+    .maybeSingle();
+
+  if (serviceError) {
+    console.error(serviceError);
+    return NextResponse.json({ error: "Unable to load service" }, { status: 500 });
+  }
+
+  if (!service || service.provider_id !== providerId) {
+    return NextResponse.json({ error: "SERVICE_NOT_FOUND" }, { status: 404 });
+  }
+
+  const dayStart = startOfDay(nextStart);
+  const dayEnd = addDays(dayStart, 1);
+
+  const { data: rules, error: rulesError } = await supabase
+    .from("availability_rules")
+    .select("id, provider_id, dow, start_time, end_time")
+    .eq("provider_id", providerId);
+
+  if (rulesError) {
+    console.error(rulesError);
+    return NextResponse.json({ error: "Unable to load availability" }, { status: 500 });
+  }
+
+  if (!rules || rules.length === 0) {
+    return NextResponse.json({ error: "NO_AVAILABILITY" }, { status: 409 });
+  }
+
+  const { data: blackoutDates, error: blackoutError } = await supabase
+    .from("blackout_dates")
+    .select("id, provider_id, day, reason")
+    .eq("provider_id", providerId);
+
+  if (blackoutError) {
+    console.error(blackoutError);
+    return NextResponse.json({ error: "Unable to load blackout dates" }, { status: 500 });
+  }
+
+  const slots = generateBookableSlots({
+    rules: rules.map((rule) => ({
+      id: rule.id,
+      providerId: rule.provider_id,
+      dow: rule.dow,
+      startTime: rule.start_time,
+      endTime: rule.end_time,
+    })),
+    blackoutDates: (blackoutDates ?? []).map((entry) => ({
+      id: entry.id,
+      providerId: entry.provider_id,
+      day: entry.day,
+      reason: entry.reason,
+    })),
+    serviceDurationMin: service.duration_min,
+    from: dayStart.toISOString(),
+    days: 1,
+  });
+
+  if (slots.length === 0) {
+    return NextResponse.json({ error: "NO_SLOTS" }, { status: 409 });
+  }
+
+  const { data: dayBookings, error: dayBookingError } = await supabase
+    .from("bookings")
+    .select("id, start_at, end_at, status")
+    .eq("provider_id", providerId)
+    .eq("service_id", service.id)
+    .in("status", ["pending", "confirmed"])
+    .neq("id", booking.id)
+    .gte("start_at", dayStart.toISOString())
+    .lt("start_at", dayEnd.toISOString());
+
+  if (dayBookingError) {
+    console.error(dayBookingError);
+    return NextResponse.json({ error: "Unable to load conflicting bookings" }, { status: 500 });
+  }
+
+  const availableSlots = filterSlotsByBookings({
+    slots,
+    bookings:
+      (dayBookings ?? []).map((existing) => ({
+        startAt: existing.start_at,
+        endAt: existing.end_at ?? existing.start_at,
+        status: existing.status as "pending" | "confirmed",
+      })) ?? [],
+  });
+
+  const requestedSlot = availableSlots.find((slot) => slot.start === nextStart.toISOString());
+
+  if (!requestedSlot) {
+    return NextResponse.json({ error: "SLOT_UNAVAILABLE" }, { status: 409 });
+  }
+
+  const now = new Date();
+  const updatePayload: { start_at: string; end_at: string; updated_at: string; notes?: string | null } = {
+    start_at: requestedSlot.start,
+    end_at: requestedSlot.end,
+    updated_at: now.toISOString(),
+  };
+
+  if (note) {
+    const combinedNotes = [booking.notes, `Reschedule note: ${note}`]
+      .filter((segment): segment is string => Boolean(segment))
+      .join("\n\n");
+    updatePayload.notes = combinedNotes;
+  }
+
+  const { error: updateError } = await supabase
+    .from("bookings")
+    .update(updatePayload)
+    .eq("id", booking.id);
+
+  if (updateError) {
+    console.error(updateError);
+    return NextResponse.json({ error: "Failed to reschedule booking" }, { status: 500 });
+  }
+
+  let feeCharged = false;
+  if (chargeCustomerFee && (provider.reschedule_fee_cents ?? 0) > 0) {
+    const { error: feeError } = await supabase.from("payments").insert({
+      booking_id: booking.id,
+      provider_id: providerId,
+      status: "succeeded",
+      amount_cents: provider.reschedule_fee_cents,
+      gateway: "manual",
+      gateway_ref: `manual_reschedule_${booking.id}_${Date.now()}`,
+      metadata: {
+        type: "reschedule_fee",
+        chargedAt: now.toISOString(),
+        currency: provider.currency,
+      },
+    });
+
+    if (feeError) {
+      console.error(feeError);
+      return NextResponse.json({ error: "Failed to record reschedule fee" }, { status: 500 });
+    }
+
+    feeCharged = true;
+  }
+
+  if (booking.customer_id) {
+    const { data: customer, error: customerError } = await supabase
+      .from("customers")
+      .select("email, name, phone")
+      .eq("id", booking.customer_id)
+      .maybeSingle();
+
+    if (customerError) {
+      console.error(customerError);
+      return NextResponse.json({ error: "Unable to load customer" }, { status: 500 });
+    }
+
+    const notifications: Database["public"]["Tables"]["notifications"]["Insert"][] = [];
+
+    const payload = {
+      type: "booking_customer_rescheduled" as const,
+      previousStartAt: booking.start_at,
+      newStartAt: requestedSlot.start,
+      feeCharged,
+      providerName: provider.display_name,
+      serviceName: service.name,
+      customerName: customer?.name ?? undefined,
+    };
+
+    if (customer?.email) {
+      notifications.push({
+        booking_id: booking.id,
+        channel: "email",
+        recipient: customer.email,
+        payload,
+      });
+    }
+
+    if (customer?.phone) {
+      notifications.push({
+        booking_id: booking.id,
+        channel: "whatsapp",
+        recipient: customer.phone,
+        payload,
+      });
+    }
+
+    if (notifications.length > 0) {
+      const { error: notificationError } = await supabase.from("notifications").insert(notifications);
+
+      if (notificationError) {
+        console.error(notificationError);
+        return NextResponse.json({ error: "Failed to queue reschedule notice" }, { status: 500 });
+      }
+    }
+  }
+
+  return NextResponse.json({
+    status: booking.status,
+    startAt: requestedSlot.start,
+    endAt: requestedSlot.end,
+    feeCharged,
+  });
+}

--- a/app/api/cron/notifications/route.ts
+++ b/app/api/cron/notifications/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+import {
+  parseNotificationPayload,
+  renderEmailTemplate,
+  renderWhatsAppTemplate,
+} from "@/lib/domain/notifications";
+import type { Database } from "@/types/database";
+
+type NotificationRow = Database["public"]["Tables"]["notifications"]["Row"];
+type NotificationUpdate = Database["public"]["Tables"]["notifications"]["Update"] & { id: string };
+
+type DispatchResult = {
+  status: "sent" | "failed";
+  error?: string;
+};
+
+function ensureCronAuthorized(request: NextRequest): NextResponse | null {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) {
+    return null;
+  }
+
+  const header = request.headers.get("authorization");
+  if (!header || header !== `Bearer ${expected}`) {
+    return NextResponse.json({ error: "UNAUTHORIZED" }, { status: 401 });
+  }
+  return null;
+}
+
+async function dispatchNotification(notification: NotificationRow): Promise<DispatchResult> {
+  const payload = parseNotificationPayload(notification.payload);
+  if (!payload) {
+    return { status: "failed", error: "INVALID_PAYLOAD" };
+  }
+
+  try {
+    if (notification.channel === "email") {
+      const { subject, body } = renderEmailTemplate(payload);
+      console.info(`[email] -> ${notification.recipient}\nSubject: ${subject}\n${body}`);
+    } else {
+      const message = renderWhatsAppTemplate(payload);
+      console.info(`[whatsapp] -> ${notification.recipient}\n${message}`);
+    }
+    return { status: "sent" };
+  } catch (error) {
+    console.error("Failed to dispatch notification", error);
+    return { status: "failed", error: error instanceof Error ? error.message : "UNKNOWN" };
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const unauthorized = ensureCronAuthorized(request);
+  if (unauthorized) {
+    return unauthorized;
+  }
+
+  let supabase;
+  try {
+    supabase = getServiceRoleClient();
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "SERVER_MISCONFIGURED" }, { status: 500 });
+  }
+
+  const { data: pending, error } = await supabase
+    .from("notifications")
+    .select("id, channel, recipient, payload")
+    .in("status", ["pending", "failed"])
+    .order("created_at", { ascending: true })
+    .limit(25);
+
+  if (error) {
+    console.error(error);
+    return NextResponse.json({ error: "FETCH_FAILED" }, { status: 500 });
+  }
+
+  if (!pending || pending.length === 0) {
+    return NextResponse.json({ processed: 0, sent: 0, failed: 0 });
+  }
+
+  const updates: NotificationUpdate[] = [];
+  let sentCount = 0;
+  let failedCount = 0;
+
+  for (const notification of pending) {
+    const result = await dispatchNotification(notification as NotificationRow);
+    const baseUpdate: NotificationUpdate = {
+      id: notification.id,
+      status: result.status,
+      sent_at: result.status === "sent" ? new Date().toISOString() : null,
+    };
+
+    if (result.status === "sent") {
+      sentCount += 1;
+    } else {
+      failedCount += 1;
+      if (result.error) {
+        console.warn(`Notification ${notification.id} failed: ${result.error}`);
+      }
+    }
+
+    updates.push(baseUpdate);
+  }
+
+  for (const update of updates) {
+    const { id, ...fields } = update;
+    const { error: updateError } = await supabase.from("notifications").update(fields).eq("id", id);
+    if (updateError) {
+      console.error("Failed to update notification status", updateError);
+    }
+  }
+
+  return NextResponse.json({ processed: pending.length, sent: sentCount, failed: failedCount });
+}

--- a/app/api/payments/webhook/route.ts
+++ b/app/api/payments/webhook/route.ts
@@ -3,7 +3,7 @@ import { MockPaymentGateway } from "@/lib/domain/payments";
 import { getServiceRoleClient } from "@/lib/supabase/server";
 import { resolvePaymentEvent } from "@/lib/domain/payment-webhook";
 import type { BookingStatus } from "@/lib/domain/types";
-import type { Json } from "@/types/database";
+import type { Database, Json } from "@/types/database";
 
 type PaymentStatus = "initiated" | "succeeded" | "failed" | "refunded";
 
@@ -11,10 +11,22 @@ type BookingRow = {
   id: string;
   status: string;
   customer_id: string | null;
+  service_id: string;
+  start_at: string;
 };
 
 type CustomerRow = {
-  email: string;
+  email: string | null;
+  name: string | null;
+  phone: string | null;
+};
+
+type ProviderRow = {
+  display_name: string;
+};
+
+type ServiceRow = {
+  id: string;
   name: string | null;
 };
 
@@ -32,9 +44,6 @@ export async function POST(request: NextRequest) {
   let payload: Json;
   try {
     payload = JSON.parse(rawBody) as Json;
-  let payload: unknown;
-  try {
-    payload = JSON.parse(rawBody);
   } catch (error) {
     console.error("Unable to parse webhook payload", error);
     return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
@@ -125,7 +134,7 @@ export async function POST(request: NextRequest) {
   if (payment.booking_id) {
     const { data: bookingRow, error: bookingError } = await supabase
       .from("bookings")
-      .select("id, status, customer_id")
+      .select("id, status, customer_id, service_id, start_at")
       .eq("id", payment.booking_id)
       .maybeSingle();
 
@@ -155,10 +164,14 @@ export async function POST(request: NextRequest) {
   }
 
   let customer: CustomerRow | null = null;
-  if (resolution.shouldCreateReceiptNotification && booking?.customer_id) {
+  const needsCustomer = Boolean(
+    booking?.customer_id && (resolution.shouldCreateReceiptNotification || resolution.shouldConfirmBooking),
+  );
+
+  if (needsCustomer && booking?.customer_id) {
     const { data: customerRow, error: customerError } = await supabase
       .from("customers")
-      .select("email, name")
+      .select("email, name, phone")
       .eq("id", booking.customer_id)
       .maybeSingle();
 
@@ -168,6 +181,38 @@ export async function POST(request: NextRequest) {
     }
 
     customer = customerRow;
+  }
+
+  let service: ServiceRow | null = null;
+  if (booking && resolution.shouldConfirmBooking) {
+    const { data: serviceRow, error: serviceError } = await supabase
+      .from("services")
+      .select("id, name")
+      .eq("id", booking.service_id)
+      .maybeSingle();
+
+    if (serviceError) {
+      console.error(serviceError);
+      return NextResponse.json({ error: "Unable to load service" }, { status: 500 });
+    }
+
+    service = serviceRow;
+  }
+
+  let providerProfile: ProviderRow | null = null;
+  if (resolution.shouldCreateReceiptNotification || resolution.shouldConfirmBooking) {
+    const { data: providerRow, error: providerError } = await supabase
+      .from("providers")
+      .select("display_name")
+      .eq("id", payment.provider_id)
+      .maybeSingle();
+
+    if (providerError) {
+      console.error(providerError);
+      return NextResponse.json({ error: "Unable to load provider" }, { status: 500 });
+    }
+
+    providerProfile = providerRow;
   }
 
   if (resolution.shouldUpdatePayment) {
@@ -185,7 +230,7 @@ export async function POST(request: NextRequest) {
   if (resolution.shouldConfirmBooking && booking) {
     const { error: updateBookingError } = await supabase
       .from("bookings")
-      .update({ status: "confirmed", updated_at: new Date().toISOString() })
+      .update({ status: "confirmed", pay_mode: "per_booking", updated_at: new Date().toISOString() })
       .eq("id", booking.id);
 
     if (updateBookingError) {
@@ -194,21 +239,71 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  if (resolution.shouldCreateReceiptNotification && booking && customer?.email) {
-    const { error: notificationError } = await supabase.from("notifications").insert({
-      booking_id: booking.id,
-      channel: "email",
-      recipient: customer.email,
-      payload: {
-        type: "per_booking_receipt",
-        amountCents: payment.amount_cents,
-        bookingId: booking.id,
-      },
-    });
+  const notifications: Database["public"]["Tables"]["notifications"]["Insert"][] = [];
+
+  if (resolution.shouldConfirmBooking && booking && providerProfile && service) {
+    const payload = {
+      type: "booking_customer_confirmed" as const,
+      bookingId: booking.id,
+      providerName: providerProfile.display_name,
+      serviceName: service.name ?? "your booking",
+      startAt: booking.start_at,
+      customerName: customer?.name ?? undefined,
+    };
+
+    if (customer?.email) {
+      notifications.push({
+        booking_id: booking.id,
+        channel: "email",
+        recipient: customer.email,
+        payload,
+      });
+    }
+
+    if (customer?.phone) {
+      notifications.push({
+        booking_id: booking.id,
+        channel: "whatsapp",
+        recipient: customer.phone,
+        payload,
+      });
+    }
+  }
+
+  if (resolution.shouldCreateReceiptNotification && booking && providerProfile) {
+    const receiptPayload = {
+      type: "per_booking_receipt" as const,
+      amountCents: payment.amount_cents,
+      bookingId: booking.id,
+      providerName: providerProfile.display_name,
+      serviceName: service?.name ?? undefined,
+    };
+
+    if (customer?.email) {
+      notifications.push({
+        booking_id: booking.id,
+        channel: "email",
+        recipient: customer.email,
+        payload: receiptPayload,
+      });
+    }
+
+    if (customer?.phone) {
+      notifications.push({
+        booking_id: booking.id,
+        channel: "whatsapp",
+        recipient: customer.phone,
+        payload: receiptPayload,
+      });
+    }
+  }
+
+  if (notifications.length > 0) {
+    const { error: notificationError } = await supabase.from("notifications").insert(notifications);
 
     if (notificationError) {
       console.error(notificationError);
-      return NextResponse.json({ error: "Failed to queue receipt" }, { status: 500 });
+      return NextResponse.json({ error: "Failed to queue notifications" }, { status: 500 });
     }
   }
 

--- a/app/api/public/booking/check/route.ts
+++ b/app/api/public/booking/check/route.ts
@@ -1,0 +1,138 @@
+import { addDays } from "date-fns";
+import { NextResponse, type NextRequest } from "next/server";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+import { checkAvailabilitySchema } from "@/lib/validation/booking";
+import { filterSlotsByBookings, generateBookableSlots } from "@/lib/domain/availability";
+import type { BookingStatus } from "@/lib/domain/types";
+
+interface BookingRow {
+  start_at: string;
+  end_at: string;
+  status: string;
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const parsed = checkAvailabilitySchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  let supabase;
+  try {
+    supabase = getServiceRoleClient();
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Server misconfigured" }, { status: 500 });
+  }
+
+  const { providerHandle, serviceId, date } = parsed.data;
+
+  const { data: provider, error: providerError } = await supabase
+    .from("providers")
+    .select("id, handle")
+    .eq("handle", providerHandle)
+    .maybeSingle();
+
+  if (providerError) {
+    console.error(providerError);
+    return NextResponse.json({ error: "Unable to load provider" }, { status: 500 });
+  }
+
+  if (!provider) {
+    return NextResponse.json({ error: "Provider not found" }, { status: 404 });
+  }
+
+  const { data: service, error: serviceError } = await supabase
+    .from("services")
+    .select("id, provider_id, duration_min, is_active")
+    .eq("id", serviceId)
+    .maybeSingle();
+
+  if (serviceError) {
+    console.error(serviceError);
+    return NextResponse.json({ error: "Unable to load service" }, { status: 500 });
+  }
+
+  if (!service || service.provider_id !== provider.id || !service.is_active) {
+    return NextResponse.json({ error: "Service not available" }, { status: 404 });
+  }
+
+  const { data: rules, error: rulesError } = await supabase
+    .from("availability_rules")
+    .select("id, provider_id, dow, start_time, end_time")
+    .eq("provider_id", provider.id);
+
+  if (rulesError) {
+    console.error(rulesError);
+    return NextResponse.json({ error: "Unable to load availability" }, { status: 500 });
+  }
+
+  const { data: blackoutDates, error: blackoutError } = await supabase
+    .from("blackout_dates")
+    .select("id, provider_id, day, reason")
+    .eq("provider_id", provider.id)
+    .gte("day", date)
+    .lte("day", date);
+
+  if (blackoutError) {
+    console.error(blackoutError);
+    return NextResponse.json({ error: "Unable to load blackout dates" }, { status: 500 });
+  }
+
+  if (!rules || rules.length === 0) {
+    return NextResponse.json({ slots: [] });
+  }
+
+  const dayStart = new Date(`${date}T00:00:00.000Z`);
+  const dayEnd = addDays(dayStart, 1);
+
+  const baseSlots = generateBookableSlots({
+    rules: rules.map((rule) => ({
+      id: rule.id,
+      providerId: rule.provider_id,
+      dow: rule.dow,
+      startTime: rule.start_time,
+      endTime: rule.end_time,
+    })),
+    blackoutDates: (blackoutDates ?? []).map((entry) => ({
+      id: entry.id,
+      providerId: entry.provider_id,
+      day: entry.day,
+      reason: entry.reason,
+    })),
+    serviceDurationMin: service.duration_min,
+    from: dayStart.toISOString(),
+    days: 1,
+  }).filter((slot) => slot.start.startsWith(date));
+
+  if (baseSlots.length === 0) {
+    return NextResponse.json({ slots: [] });
+  }
+
+  const { data: bookings, error: bookingsError } = await supabase
+    .from("bookings")
+    .select("start_at, end_at, status")
+    .eq("provider_id", provider.id)
+    .eq("service_id", service.id)
+    .in("status", ["pending", "confirmed"])
+    .gte("start_at", dayStart.toISOString())
+    .lt("start_at", dayEnd.toISOString());
+
+  if (bookingsError) {
+    console.error(bookingsError);
+    return NextResponse.json({ error: "Unable to load bookings" }, { status: 500 });
+  }
+
+  const availableSlots = filterSlotsByBookings({
+    slots: baseSlots,
+    bookings: (bookings as BookingRow[] | null)?.map((booking) => ({
+      startAt: booking.start_at,
+      endAt: booking.end_at,
+      status: booking.status as BookingStatus,
+    })) ?? [],
+  });
+
+  return NextResponse.json({ slots: availableSlots });
+}

--- a/app/api/public/booking/create/route.ts
+++ b/app/api/public/booking/create/route.ts
@@ -1,7 +1,15 @@
-import { addMinutes } from "date-fns";
+import { addDays, isBefore } from "date-fns";
 import { NextResponse, type NextRequest } from "next/server";
 import { getServiceRoleClient } from "@/lib/supabase/server";
 import { createBookingSchema } from "@/lib/validation/booking";
+import { filterSlotsByBookings, generateBookableSlots } from "@/lib/domain/availability";
+import type { Database } from "@/types/database";
+
+interface BookingWindowRow {
+  start_at: string;
+  end_at: string;
+  status: string;
+}
 
 export async function POST(request: NextRequest) {
   const body = await request.json();
@@ -23,7 +31,7 @@ export async function POST(request: NextRequest) {
 
   const { data: provider, error: providerError } = await supabase
     .from("providers")
-    .select("id, currency, handle")
+    .select("id, currency, handle, display_name")
     .eq("handle", providerHandle)
     .maybeSingle();
 
@@ -38,7 +46,7 @@ export async function POST(request: NextRequest) {
 
   const { data: service, error: serviceError } = await supabase
     .from("services")
-    .select("id, provider_id, duration_min, base_price_cents, is_active")
+    .select("id, provider_id, duration_min, base_price_cents, is_active, name")
     .eq("id", serviceId)
     .maybeSingle();
 
@@ -52,7 +60,97 @@ export async function POST(request: NextRequest) {
   }
 
   const startDate = new Date(startAt);
-  const endDate = addMinutes(startDate, service.duration_min);
+
+  if (Number.isNaN(startDate.getTime())) {
+    return NextResponse.json({ error: "Invalid start time" }, { status: 400 });
+  }
+
+  if (isBefore(startDate, new Date())) {
+    return NextResponse.json({ error: "Selected time is in the past" }, { status: 409 });
+  }
+
+  const { data: rules, error: rulesError } = await supabase
+    .from("availability_rules")
+    .select("id, provider_id, dow, start_time, end_time")
+    .eq("provider_id", provider.id);
+
+  if (rulesError) {
+    console.error(rulesError);
+    return NextResponse.json({ error: "Unable to load availability" }, { status: 500 });
+  }
+
+  if (!rules || rules.length === 0) {
+    return NextResponse.json({ error: "No availability configured" }, { status: 409 });
+  }
+
+  const { data: blackoutDates, error: blackoutError } = await supabase
+    .from("blackout_dates")
+    .select("id, provider_id, day, reason")
+    .eq("provider_id", provider.id);
+
+  if (blackoutError) {
+    console.error(blackoutError);
+    return NextResponse.json({ error: "Unable to load blackout dates" }, { status: 500 });
+  }
+
+  const dayStart = new Date(startDate);
+  dayStart.setUTCHours(0, 0, 0, 0);
+  const dayEnd = addDays(dayStart, 1);
+
+  const baseSlots = generateBookableSlots({
+    rules: rules.map((rule) => ({
+      id: rule.id,
+      providerId: rule.provider_id,
+      dow: rule.dow,
+      startTime: rule.start_time,
+      endTime: rule.end_time,
+    })),
+    blackoutDates: (blackoutDates ?? []).map((entry) => ({
+      id: entry.id,
+      providerId: entry.provider_id,
+      day: entry.day,
+      reason: entry.reason,
+    })),
+    serviceDurationMin: service.duration_min,
+    from: dayStart.toISOString(),
+    days: 1,
+  });
+
+  if (baseSlots.length === 0) {
+    return NextResponse.json({ error: "Selected day has no availability" }, { status: 409 });
+  }
+
+  const { data: bookings, error: bookingsError } = await supabase
+    .from("bookings")
+    .select("start_at, end_at, status")
+    .eq("provider_id", provider.id)
+    .eq("service_id", service.id)
+    .in("status", ["pending", "confirmed"])
+    .gte("start_at", dayStart.toISOString())
+    .lt("start_at", dayEnd.toISOString());
+
+  if (bookingsError) {
+    console.error(bookingsError);
+    return NextResponse.json({ error: "Unable to load bookings" }, { status: 500 });
+  }
+
+  const availableSlots = filterSlotsByBookings({
+    slots: baseSlots,
+    bookings:
+      (bookings as BookingWindowRow[] | null)?.map((booking) => ({
+        startAt: booking.start_at,
+        endAt: booking.end_at,
+        status: booking.status as "pending" | "confirmed",
+      })) ?? [],
+  });
+
+  const requestedSlot = availableSlots.find((slot) => slot.start === startDate.toISOString());
+
+  if (!requestedSlot) {
+    return NextResponse.json({ error: "Slot no longer available" }, { status: 409 });
+  }
+
+  const endDate = new Date(requestedSlot.end);
 
   const { data: customerRow, error: customerError } = await supabase
     .from("customers")
@@ -82,8 +180,8 @@ export async function POST(request: NextRequest) {
       provider_id: provider.id,
       service_id: service.id,
       customer_id: customerRow.id,
-      start_at: startDate.toISOString(),
-      end_at: endDate.toISOString(),
+      start_at: requestedSlot.start,
+      end_at: requestedSlot.end,
       status: "pending",
       notes: notes ?? null,
     })
@@ -95,12 +193,57 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unable to create booking" }, { status: 500 });
   }
 
+  if (!booking) {
+    return NextResponse.json({ error: "Unable to create booking" }, { status: 500 });
+  }
+
+  const notifications: Database["public"]["Tables"]["notifications"]["Insert"][] = [
+    {
+      booking_id: booking.id,
+      channel: "email" as const,
+      recipient: customer.email,
+      payload: {
+        type: "booking_customer_pending" as const,
+        bookingId: booking.id,
+        providerHandle: provider.handle,
+        providerName: provider.display_name ?? provider.handle,
+        serviceName: service.name,
+        startAt: booking.start_at,
+        customerName: customer.name,
+      },
+    },
+  ];
+
+  if (customerRow.phone) {
+    notifications.push({
+      booking_id: booking.id,
+      channel: "whatsapp" as const,
+      recipient: customerRow.phone,
+      payload: {
+        type: "booking_customer_pending" as const,
+        bookingId: booking.id,
+        providerHandle: provider.handle,
+        providerName: provider.display_name ?? provider.handle,
+        serviceName: service.name,
+        startAt: booking.start_at,
+        customerName: customer.name,
+      },
+    });
+  }
+
+  const { error: notificationError } = await supabase.from("notifications").insert(notifications);
+
+  if (notificationError) {
+    console.error(notificationError);
+    return NextResponse.json({ error: "Failed to queue notification" }, { status: 500 });
+  }
+
   return NextResponse.json({
     booking: {
-      id: booking?.id,
-      startAt: booking?.start_at,
-      endAt: booking?.end_at,
-      status: booking?.status,
+      id: booking.id,
+      startAt: booking.start_at,
+      endAt: booking.end_at,
+      status: booking.status,
     },
     message: "Booking received. We will confirm shortly via WhatsApp and email.",
   });

--- a/app/api/wallet/topup/route.ts
+++ b/app/api/wallet/topup/route.ts
@@ -1,0 +1,160 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getRouteHandlerClient, getServiceRoleClient } from "@/lib/supabase/server";
+import { walletTopupSchema } from "@/lib/validation/wallet";
+import { addCreditsToWallet } from "@/lib/domain/wallet";
+import { MockPaymentGateway } from "@/lib/domain/payments";
+
+const CREDIT_PRICE_CENTS = 100;
+
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => null);
+
+  const parsed = walletTopupSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "INVALID_REQUEST", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const authClient = getRouteHandlerClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await authClient.auth.getUser();
+
+  if (authError) {
+    console.error(authError);
+    return NextResponse.json({ error: "AUTH_ERROR" }, { status: 500 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  }
+
+  const { data: provider, error: providerError } = await authClient
+    .from("providers")
+    .select("id, currency")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (providerError) {
+    console.error(providerError);
+    return NextResponse.json({ error: "PROVIDER_LOOKUP_FAILED" }, { status: 500 });
+  }
+
+  if (!provider) {
+    return NextResponse.json({ error: "PROVIDER_NOT_FOUND" }, { status: 404 });
+  }
+
+  const supabase = getServiceRoleClient();
+
+  const { data: existingWallet, error: walletFetchError } = await supabase
+    .from("wallets")
+    .select("id, balance_credits, currency")
+    .eq("provider_id", provider.id)
+    .maybeSingle();
+
+  if (walletFetchError) {
+    console.error(walletFetchError);
+    return NextResponse.json({ error: "WALLET_FETCH_FAILED" }, { status: 500 });
+  }
+
+  let walletRecord = existingWallet;
+
+  if (!walletRecord) {
+    const { data: insertedWallet, error: walletInsertError } = await supabase
+      .from("wallets")
+      .insert({ provider_id: provider.id, balance_credits: 0, currency: provider.currency })
+      .select("id, balance_credits, currency")
+      .single();
+
+    if (walletInsertError) {
+      console.error(walletInsertError);
+      return NextResponse.json({ error: "WALLET_CREATE_FAILED" }, { status: 500 });
+    }
+
+    walletRecord = insertedWallet;
+  }
+
+  const domainWallet = {
+    id: walletRecord.id,
+    providerId: provider.id,
+    balanceCredits: walletRecord.balance_credits,
+    currency: walletRecord.currency,
+  } as const;
+
+  let outcome;
+  try {
+    outcome = addCreditsToWallet(domainWallet, parsed.data.credits);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "TOPUP_NOT_ALLOWED" }, { status: 400 });
+  }
+
+  const { error: walletUpdateError } = await supabase
+    .from("wallets")
+    .update({ balance_credits: outcome.wallet.balanceCredits })
+    .eq("id", walletRecord.id);
+
+  if (walletUpdateError) {
+    console.error(walletUpdateError);
+    return NextResponse.json({ error: "WALLET_UPDATE_FAILED" }, { status: 500 });
+  }
+
+  const { error: ledgerInsertError } = await supabase.from("wallet_ledger").insert({
+    id: outcome.ledgerEntry.id,
+    wallet_id: walletRecord.id,
+    change_credits: outcome.ledgerEntry.changeCredits,
+    description: outcome.ledgerEntry.description,
+  });
+
+  if (ledgerInsertError) {
+    console.error(ledgerInsertError);
+    // Attempt to revert wallet balance to previous amount to keep data consistent
+    await supabase
+      .from("wallets")
+      .update({ balance_credits: walletRecord.balance_credits })
+      .eq("id", walletRecord.id);
+
+    return NextResponse.json({ error: "LEDGER_WRITE_FAILED" }, { status: 500 });
+  }
+
+  const paymentGateway = new MockPaymentGateway();
+  const { checkoutUrl } = await paymentGateway.createTopupIntent(provider.id, parsed.data.credits);
+  const amountCents = parsed.data.credits * CREDIT_PRICE_CENTS;
+
+  const { error: paymentInsertError } = await supabase.from("payments").insert({
+    provider_id: provider.id,
+    status: "succeeded",
+    amount_cents: amountCents,
+    gateway: "mockpay",
+    gateway_ref: `mockpay_topup_${outcome.ledgerEntry.id}`,
+    metadata: {
+      strategy: "credit_topup",
+      credits: parsed.data.credits,
+      checkoutUrl,
+    },
+  });
+
+  if (paymentInsertError) {
+    console.error(paymentInsertError);
+  }
+
+  return NextResponse.json({
+    status: "succeeded",
+    wallet: {
+      id: walletRecord.id,
+      balanceCredits: outcome.wallet.balanceCredits,
+      currency: outcome.wallet.currency,
+    },
+    ledgerEntry: {
+      id: outcome.ledgerEntry.id,
+      changeCredits: outcome.ledgerEntry.changeCredits,
+      description: outcome.ledgerEntry.description,
+    },
+    payment: {
+      amountCents,
+      gateway: "mockpay",
+      checkoutUrl,
+    },
+  });
+}

--- a/components/public-booking-widget.tsx
+++ b/components/public-booking-widget.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { addDays, format } from "date-fns";
+import { AvailabilitySlotPicker } from "@/components/availability-slot-picker";
+import { ServiceList } from "@/components/service-list";
+import type { AvailabilitySlot } from "@/lib/domain/availability";
+import type { AvailabilityRule, BlackoutDate, ProviderProfile, Service } from "@/lib/domain/types";
+
+interface BookingWidgetProps {
+  provider: ProviderProfile;
+  services: Service[];
+  availability: AvailabilityRule[];
+  blackoutDates: BlackoutDate[];
+}
+
+interface DayOption {
+  label: string;
+  value: string;
+  disabled: boolean;
+}
+
+type SubmissionState =
+  | { status: "idle" | "submitting" }
+  | { status: "success"; message: string }
+  | { status: "error"; message: string };
+
+export function pickFirstOpenDate(availability: AvailabilityRule[], blackoutDates: BlackoutDate[]): string {
+  const blackoutSet = new Set(blackoutDates.map((entry) => entry.day));
+  const availableDow = new Set(availability.map((rule) => rule.dow));
+  const today = new Date();
+
+  for (let index = 0; index < 14; index += 1) {
+    const day = addDays(today, index);
+    const value = format(day, "yyyy-MM-dd");
+    if (!availableDow.has(day.getDay())) {
+      continue;
+    }
+    if (blackoutSet.has(value)) {
+      continue;
+    }
+    return value;
+  }
+
+  return format(today, "yyyy-MM-dd");
+}
+
+export function PublicBookingWidget({ provider, services, availability, blackoutDates }: BookingWidgetProps) {
+  const [selectedServiceId, setSelectedServiceId] = useState<string | null>(services[0]?.id ?? null);
+  const [selectedDate, setSelectedDate] = useState<string>(() => pickFirstOpenDate(availability, blackoutDates));
+  const [slots, setSlots] = useState<AvailabilitySlot[]>([]);
+  const [slotsError, setSlotsError] = useState<string | null>(null);
+  const [loadingSlots, setLoadingSlots] = useState<boolean>(false);
+  const [selectedSlot, setSelectedSlot] = useState<AvailabilitySlot | null>(null);
+  const [customerName, setCustomerName] = useState("");
+  const [customerEmail, setCustomerEmail] = useState("");
+  const [customerPhone, setCustomerPhone] = useState("");
+  const [notes, setNotes] = useState("");
+  const [submission, setSubmission] = useState<SubmissionState>({ status: "idle" });
+
+  const dayOptions = useMemo<DayOption[]>(() => {
+    const blackoutSet = new Set(blackoutDates.map((entry) => entry.day));
+    const availableDow = new Set(availability.map((rule) => rule.dow));
+
+    return Array.from({ length: 14 }, (_, index) => {
+      const day = addDays(new Date(), index);
+      const value = format(day, "yyyy-MM-dd");
+      const disabled = blackoutSet.has(value) || !availableDow.has(day.getDay());
+      return {
+        value,
+        label: format(day, "EEE MMM d"),
+        disabled,
+      };
+    });
+  }, [availability, blackoutDates]);
+
+  const selectedService = useMemo(() => services.find((service) => service.id === selectedServiceId) ?? null, [
+    services,
+    selectedServiceId,
+  ]);
+
+  useEffect(() => {
+    if (!selectedService) {
+      setSlots([]);
+      setSelectedSlot(null);
+      return;
+    }
+
+    const serviceId = selectedService.id;
+
+    let isCancelled = false;
+    async function fetchSlots() {
+      setLoadingSlots(true);
+      setSlotsError(null);
+      setSelectedSlot(null);
+
+      try {
+        const response = await fetch("/api/public/booking/check", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            providerHandle: provider.handle,
+            serviceId,
+            date: selectedDate,
+          }),
+        });
+
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({ error: "Unable to load availability" }));
+          throw new Error(body.error ?? "Unable to load availability");
+        }
+
+        const data = (await response.json()) as { slots: AvailabilitySlot[] };
+        if (!isCancelled) {
+          setSlots(data.slots);
+        }
+      } catch (error) {
+        if (!isCancelled) {
+          setSlots([]);
+          setSlotsError(error instanceof Error ? error.message : "Unable to load availability");
+        }
+      } finally {
+        if (!isCancelled) {
+          setLoadingSlots(false);
+        }
+      }
+    }
+
+    fetchSlots();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [provider.handle, selectedDate, selectedService]);
+
+  const isSubmitDisabled =
+    !selectedService ||
+    !selectedSlot ||
+    !customerName.trim() ||
+    !customerEmail.trim() ||
+    !customerPhone.trim() ||
+    submission.status === "submitting";
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selectedService || !selectedSlot) {
+      setSubmission({ status: "error", message: "Select a service and time" });
+      return;
+    }
+
+    setSubmission({ status: "submitting" });
+
+    const serviceId = selectedService.id;
+    const slotStart = selectedSlot.start;
+
+    try {
+      const response = await fetch("/api/public/booking/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          providerHandle: provider.handle,
+          serviceId,
+          startAt: slotStart,
+          customer: {
+            name: customerName,
+            email: customerEmail,
+            phone: customerPhone,
+          },
+          notes: notes.trim() ? notes.trim() : undefined,
+        }),
+      });
+
+      const body = await response.json().catch(() => ({ error: "Unable to place booking" }));
+
+      if (!response.ok) {
+        throw new Error(body.error ?? "Unable to place booking");
+      }
+
+      setSubmission({ status: "success", message: body.message ?? "Booking request received" });
+      setSlots((current) => current.filter((slot) => slot.start !== slotStart));
+      setSelectedSlot(null);
+    } catch (error) {
+      setSubmission({ status: "error", message: error instanceof Error ? error.message : "Unable to place booking" });
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-white">Services</h2>
+        <ServiceList
+          services={services}
+          currency={provider.currency}
+          onSelect={(service) => setSelectedServiceId(service.id)}
+          selectedServiceId={selectedServiceId ?? undefined}
+        />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-white">Pick a day</h2>
+        <div className="flex flex-wrap gap-2">
+          {dayOptions.map((option) => {
+            const isSelected = option.value === selectedDate;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setSelectedDate(option.value)}
+                disabled={option.disabled}
+                className={`rounded-full border px-3 py-1 text-sm transition ${
+                  option.disabled
+                    ? "cursor-not-allowed border-slate-800 bg-slate-900 text-slate-500"
+                    : isSelected
+                      ? "border-accent bg-accent/20 text-white"
+                      : "border-slate-700 bg-slate-900 hover:border-accent/60"
+                }`}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold text-white">Available slots</h2>
+        {slotsError ? <p className="text-sm text-red-400">{slotsError}</p> : null}
+        {loadingSlots ? <p className="text-sm text-slate-400">Loading availability…</p> : null}
+        {!loadingSlots && !slotsError ? (
+          <AvailabilitySlotPicker
+            slots={slots}
+            onSelect={(slot) => setSelectedSlot(slot)}
+          />
+        ) : null}
+        {selectedService ? (
+          <p className="text-xs text-slate-400">
+            Each {selectedService.name.toLowerCase()} runs {selectedService.durationMin} minutes. We&apos;ll confirm via email and
+            WhatsApp once your provider approves.
+          </p>
+        ) : null}
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-white">Your details</h2>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="flex flex-col gap-1 text-sm text-slate-200">
+              Full name
+              <input
+                required
+                value={customerName}
+                onChange={(event) => setCustomerName(event.target.value)}
+                className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-white focus:border-accent focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm text-slate-200">
+              Email
+              <input
+                type="email"
+                required
+                value={customerEmail}
+                onChange={(event) => setCustomerEmail(event.target.value)}
+                className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-white focus:border-accent focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm text-slate-200">
+              Phone (WhatsApp)
+              <input
+                required
+                value={customerPhone}
+                onChange={(event) => setCustomerPhone(event.target.value)}
+                className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-white focus:border-accent focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm text-slate-200">
+              Notes (optional)
+              <textarea
+                value={notes}
+                onChange={(event) => setNotes(event.target.value)}
+                rows={3}
+                className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-white focus:border-accent focus:outline-none"
+              />
+            </label>
+          </div>
+          <div className="space-y-2">
+            <button
+              type="submit"
+              disabled={isSubmitDisabled}
+              className="w-full rounded-md bg-accent px-4 py-2 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:bg-slate-700"
+            >
+              {submission.status === "submitting" ? "Sending request…" : "Request booking"}
+            </button>
+            {submission.status === "error" ? (
+              <p className="text-sm text-red-400">{submission.message}</p>
+            ) : null}
+            {submission.status === "success" ? (
+              <p className="text-sm text-emerald-400">{submission.message}</p>
+            ) : null}
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/lib/domain/booking-policy.ts
+++ b/lib/domain/booking-policy.ts
@@ -1,0 +1,35 @@
+import { differenceInMinutes } from "date-fns";
+
+export interface CancellationPolicyInput {
+  bookingStartAt: string;
+  lateCancelHours: number;
+  now?: Date;
+}
+
+export interface CancellationPolicyResult {
+  isLate: boolean;
+  refundEligible: boolean;
+  minutesUntilStart: number;
+}
+
+export function evaluateCancellationPolicy({
+  bookingStartAt,
+  lateCancelHours,
+  now = new Date(),
+}: CancellationPolicyInput): CancellationPolicyResult {
+  const startAt = new Date(bookingStartAt);
+
+  if (Number.isNaN(startAt.getTime())) {
+    throw new Error("INVALID_START_AT");
+  }
+
+  const minutesUntilStart = differenceInMinutes(startAt, now);
+  const cutoffMinutes = Math.max(0, lateCancelHours) * 60;
+  const refundEligible = minutesUntilStart >= cutoffMinutes;
+
+  return {
+    isLate: !refundEligible,
+    refundEligible,
+    minutesUntilStart,
+  };
+}

--- a/lib/domain/notifications.ts
+++ b/lib/domain/notifications.ts
@@ -1,0 +1,200 @@
+import { format } from "date-fns";
+import { z } from "zod";
+
+const DATE_FORMAT = "eee, MMM d 'at' h:mmaaa";
+const currencyFormatter = new Intl.NumberFormat("en-JM", {
+  style: "currency",
+  currency: "JMD",
+  minimumFractionDigits: 0,
+});
+
+function safeFormatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return format(date, DATE_FORMAT);
+}
+
+function formatCurrency(amountCents: number): string {
+  return currencyFormatter.format(amountCents / 100);
+}
+
+const baseCustomerPayload = z.object({
+  providerName: z.string(),
+  serviceName: z.string(),
+  customerName: z.string().optional(),
+});
+
+export const notificationPayloadSchema = z.discriminatedUnion("type", [
+  z
+    .object({
+      type: z.literal("booking_customer_pending"),
+      bookingId: z.string().uuid(),
+      providerHandle: z.string(),
+      startAt: z.string(),
+    })
+    .merge(baseCustomerPayload),
+  z
+    .object({
+      type: z.literal("booking_customer_confirmed"),
+      bookingId: z.string().uuid(),
+      startAt: z.string(),
+    })
+    .merge(baseCustomerPayload),
+  z
+    .object({
+      type: z.literal("booking_customer_cancelled"),
+      cancelledBy: z.enum(["provider", "customer"]),
+      startAt: z.string(),
+      refundIssued: z.boolean(),
+    })
+    .merge(baseCustomerPayload),
+  z
+    .object({
+      type: z.literal("booking_customer_rescheduled"),
+      previousStartAt: z.string(),
+      newStartAt: z.string(),
+      feeCharged: z.boolean(),
+    })
+    .merge(baseCustomerPayload),
+  z.object({
+    type: z.literal("per_booking_receipt"),
+    bookingId: z.string().uuid(),
+    amountCents: z.number().nonnegative(),
+    providerName: z.string(),
+    serviceName: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal("provider_low_credits_warning"),
+    providerName: z.string(),
+    creditsRemaining: z.number().int().nonnegative(),
+  }),
+]);
+
+export type NotificationPayload = z.infer<typeof notificationPayloadSchema>;
+
+export function parseNotificationPayload(payload: unknown): NotificationPayload | null {
+  const parsed = notificationPayloadSchema.safeParse(payload);
+  if (!parsed.success) {
+    return null;
+  }
+  return parsed.data;
+}
+
+export function renderEmailTemplate(payload: NotificationPayload): { subject: string; body: string } {
+  switch (payload.type) {
+    case "booking_customer_pending": {
+      const greeting = payload.customerName ? `Hi ${payload.customerName},` : "Hi there,";
+      return {
+        subject: `We got your request for ${payload.serviceName}`,
+        body: [
+          greeting,
+          `\n`,
+          `${payload.providerName} received your booking for ${payload.serviceName} on ${safeFormatDate(payload.startAt)}.`,
+          " We'll reach out once it's confirmed.",
+          "\n\n",
+          `Need to make changes? Reply here or visit booknpay.com/@${payload.providerHandle}.`,
+        ].join(""),
+      };
+    }
+    case "booking_customer_confirmed": {
+      const greeting = payload.customerName ? `Hi ${payload.customerName},` : "Hi there,";
+      return {
+        subject: `You're booked with ${payload.providerName}`,
+        body: [
+          greeting,
+          "\n",
+          `Your ${payload.serviceName} appointment is confirmed for ${safeFormatDate(payload.startAt)}.`,
+          "\n\n",
+          "See you soon!",
+        ].join(""),
+      };
+    }
+    case "booking_customer_cancelled": {
+      const greeting = payload.customerName ? `Hi ${payload.customerName},` : "Hi there,";
+      const whoCancelled = payload.cancelledBy === "provider" ? payload.providerName : "you";
+      const refundLine = payload.refundIssued
+        ? "Any fees paid have been refunded."
+        : "This appointment won't be billed.";
+      return {
+        subject: `Booking cancelled — ${payload.serviceName}`,
+        body: [
+          greeting,
+          "\n",
+          `${payload.serviceName} on ${safeFormatDate(payload.startAt)} was cancelled by ${whoCancelled}.`,
+          "\n",
+          refundLine,
+        ].join(""),
+      };
+    }
+    case "booking_customer_rescheduled": {
+      const greeting = payload.customerName ? `Hi ${payload.customerName},` : "Hi there,";
+      const feeLine = payload.feeCharged
+        ? "A small reschedule fee was applied and shows on your receipt."
+        : "No extra fees were charged.";
+      return {
+        subject: `New time for ${payload.serviceName}`,
+        body: [
+          greeting,
+          "\n",
+          `${payload.providerName} moved your ${payload.serviceName} from ${safeFormatDate(payload.previousStartAt)} to ${safeFormatDate(payload.newStartAt)}.`,
+          "\n",
+          feeLine,
+        ].join(""),
+      };
+    }
+    case "per_booking_receipt": {
+      const amount = formatCurrency(payload.amountCents);
+      return {
+        subject: `Receipt — ${payload.providerName}`,
+        body: [
+          `Thanks for booking with ${payload.providerName}.`,
+          "\n",
+          `We received ${amount}`,
+          payload.serviceName ? ` for ${payload.serviceName}.` : ".",
+          "\n",
+          "See you soon!",
+        ].join(""),
+      };
+    }
+    case "provider_low_credits_warning": {
+      return {
+        subject: `Heads up — only ${payload.creditsRemaining} credits left`,
+        body: [
+          `Hi ${payload.providerName},`,
+          "\n",
+          `You're down to ${payload.creditsRemaining} booking credit${payload.creditsRemaining === 1 ? "" : "s"}.`,
+          " Top up to keep confirming bookings without interruption.",
+        ].join(""),
+      };
+    }
+    default: {
+      const exhaustiveCheck: never = payload;
+      return exhaustiveCheck;
+    }
+  }
+}
+
+export function renderWhatsAppTemplate(payload: NotificationPayload): string {
+  switch (payload.type) {
+    case "booking_customer_pending":
+      return `✅ ${payload.providerName} got your request for ${payload.serviceName} on ${safeFormatDate(payload.startAt)}. We'll confirm shortly.`;
+    case "booking_customer_confirmed":
+      return `🎉 Confirmed! ${payload.serviceName} with ${payload.providerName} on ${safeFormatDate(payload.startAt)}.`;
+    case "booking_customer_cancelled":
+      return `⚠️ ${payload.serviceName} on ${safeFormatDate(payload.startAt)} was cancelled. ${payload.refundIssued ? "Any payments have been refunded." : "No charges will apply."}`;
+    case "booking_customer_rescheduled":
+      return `🔁 New time: ${payload.serviceName} now starts ${safeFormatDate(payload.newStartAt)} (was ${safeFormatDate(payload.previousStartAt)}).`;
+    case "per_booking_receipt": {
+      const amount = formatCurrency(payload.amountCents);
+      return `🧾 Receipt: ${amount} received for ${payload.serviceName ?? "your booking"} with ${payload.providerName}.`;
+    }
+    case "provider_low_credits_warning":
+      return `⚡ ${payload.providerName}, you have ${payload.creditsRemaining} booking credit${payload.creditsRemaining === 1 ? "" : "s"} left. Top up soon!`;
+    default: {
+      const exhaustiveCheck: never = payload;
+      return exhaustiveCheck;
+    }
+  }
+}

--- a/lib/domain/payments.ts
+++ b/lib/domain/payments.ts
@@ -4,7 +4,6 @@ export interface PaymentGateway {
     bookingId: string,
     amountCents: number,
   ): Promise<{ checkoutUrl: string; reference: string }>;
-  createPerBookingIntent(bookingId: string, amountCents: number): Promise<{ checkoutUrl: string }>;
   verifyWebhook(sig: string, rawBody: string): boolean;
   parseEvent(rawBody: string): { type: "payment.succeeded" | "payment.failed"; refId: string };
 }
@@ -13,6 +12,7 @@ export class MockPaymentGateway implements PaymentGateway {
   async createTopupIntent(providerId: string, credits: number): Promise<{ checkoutUrl: string }> {
     return { checkoutUrl: `https://mockpay.local/topup?provider=${providerId}&credits=${credits}` };
   }
+
   async createPerBookingIntent(
     bookingId: string,
     amountCents: number,
@@ -25,13 +25,6 @@ export class MockPaymentGateway implements PaymentGateway {
   }
 
   verifyWebhook(_sig: string, _rawBody: string): boolean {
-    
-  async createPerBookingIntent(bookingId: string, amountCents: number): Promise<{ checkoutUrl: string }> {
-    return { checkoutUrl: `https://mockpay.local/booking/${bookingId}?amount=${amountCents}` };
-  }
-
-  verifyWebhook(): boolean {
-  
     return true;
   }
 

--- a/lib/domain/reporting.ts
+++ b/lib/domain/reporting.ts
@@ -1,0 +1,167 @@
+import { addDays, startOfDay, startOfWeek, subDays } from "date-fns";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database";
+
+export const RECENT_CONVERSION_WINDOW_DAYS = 30;
+
+export interface ProviderDashboardSummary {
+  upcomingConfirmed: number;
+  todayConfirmed: number;
+  weekConfirmed: number;
+  pendingCount: number;
+  recentConversion: {
+    confirmed: number;
+    total: number;
+    ratePercent: number;
+    windowDays: number;
+  };
+}
+
+export interface UpcomingBookingSummary {
+  id: string;
+  startAt: string;
+  serviceName: string;
+  serviceDurationMin: number | null;
+  customerName: string;
+  customerPhone: string | null;
+}
+
+export function calculateConversionRate(confirmed: number, total: number): number {
+  if (confirmed <= 0 || total <= 0) {
+    return 0;
+  }
+
+  const percent = (confirmed / total) * 100;
+  return Math.round(percent * 10) / 10;
+}
+
+export async function fetchProviderDashboardSummary(
+  supabase: SupabaseClient<Database>,
+  providerId: string,
+  now: Date = new Date(),
+): Promise<ProviderDashboardSummary> {
+  const todayStart = startOfDay(now);
+  const tomorrowStart = addDays(todayStart, 1);
+  const weekStart = startOfWeek(now, { weekStartsOn: 1 });
+  const weekEnd = addDays(weekStart, 7);
+  const recentWindowStart = subDays(now, RECENT_CONVERSION_WINDOW_DAYS);
+
+  const queries = await Promise.all([
+    supabase
+      .from("bookings")
+      .select("id", { count: "exact", head: true })
+      .eq("provider_id", providerId)
+      .eq("status", "confirmed")
+      .gte("start_at", now.toISOString()),
+    supabase
+      .from("bookings")
+      .select("id", { count: "exact", head: true })
+      .eq("provider_id", providerId)
+      .eq("status", "confirmed")
+      .gte("start_at", todayStart.toISOString())
+      .lt("start_at", tomorrowStart.toISOString()),
+    supabase
+      .from("bookings")
+      .select("id", { count: "exact", head: true })
+      .eq("provider_id", providerId)
+      .eq("status", "confirmed")
+      .gte("start_at", weekStart.toISOString())
+      .lt("start_at", weekEnd.toISOString()),
+    supabase
+      .from("bookings")
+      .select("id", { count: "exact", head: true })
+      .eq("provider_id", providerId)
+      .eq("status", "pending"),
+    supabase
+      .from("bookings")
+      .select("id", { count: "exact", head: true })
+      .eq("provider_id", providerId)
+      .eq("status", "confirmed")
+      .gte("created_at", recentWindowStart.toISOString()),
+    supabase
+      .from("bookings")
+      .select("id", { count: "exact", head: true })
+      .eq("provider_id", providerId)
+      .eq("status", "pending")
+      .gte("created_at", recentWindowStart.toISOString()),
+  ]);
+
+  const [upcomingRes, todayRes, weekRes, pendingRes, recentConfirmedRes, recentPendingRes] = queries;
+
+  const responses = [
+    { label: "upcoming", response: upcomingRes },
+    { label: "today", response: todayRes },
+    { label: "week", response: weekRes },
+    { label: "pending", response: pendingRes },
+    { label: "recent confirmed", response: recentConfirmedRes },
+    { label: "recent pending", response: recentPendingRes },
+  ];
+
+  for (const { label, response } of responses) {
+    if (response.error) {
+      throw new Error(`Failed to load ${label} bookings: ${response.error.message}`);
+    }
+  }
+
+  const upcomingConfirmed = upcomingRes.count ?? 0;
+  const todayConfirmed = todayRes.count ?? 0;
+  const weekConfirmed = weekRes.count ?? 0;
+  const pendingCount = pendingRes.count ?? 0;
+  const recentConfirmed = recentConfirmedRes.count ?? 0;
+  const recentPending = recentPendingRes.count ?? 0;
+  const recentTotal = recentConfirmed + recentPending;
+
+  return {
+    upcomingConfirmed,
+    todayConfirmed,
+    weekConfirmed,
+    pendingCount,
+    recentConversion: {
+      confirmed: recentConfirmed,
+      total: recentTotal,
+      ratePercent: calculateConversionRate(recentConfirmed, recentTotal),
+      windowDays: RECENT_CONVERSION_WINDOW_DAYS,
+    },
+  };
+}
+
+type UpcomingBookingRow = {
+  id: string;
+  start_at: string;
+  services?: { name?: string | null; duration_min?: number | null } | null;
+  customers?: { name?: string | null; phone?: string | null } | null;
+};
+
+export async function fetchUpcomingBookings(
+  supabase: SupabaseClient<Database>,
+  providerId: string,
+  now: Date = new Date(),
+): Promise<UpcomingBookingSummary[]> {
+  const todayStart = startOfDay(now);
+
+  const { data, error } = await supabase
+    .from("bookings")
+    .select(
+      "id, start_at, status, customers(name, phone), services(name, duration_min)",
+    )
+    .eq("provider_id", providerId)
+    .eq("status", "confirmed")
+    .gte("start_at", todayStart.toISOString())
+    .order("start_at", { ascending: true })
+    .limit(5);
+
+  if (error) {
+    throw new Error(`Failed to load upcoming bookings: ${error.message}`);
+  }
+
+  const rows = (data ?? []) as UpcomingBookingRow[];
+
+  return rows.map((booking) => ({
+    id: booking.id,
+    startAt: booking.start_at,
+    serviceName: booking.services?.name ?? "Service", // fallback when relations are missing
+    serviceDurationMin: booking.services?.duration_min ?? null,
+    customerName: booking.customers?.name ?? "Client",
+    customerPhone: booking.customers?.phone ?? null,
+  }));
+}

--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -6,6 +6,8 @@ export interface ProviderProfile {
   handle: string;
   bio: string | null;
   currency: string;
+  rescheduleFeeCents: number;
+  lateCancelHours: number;
 }
 
 export interface Service {
@@ -43,6 +45,7 @@ export interface Booking {
   startAt: string;
   endAt: string;
   status: BookingStatus;
+  payMode?: "credit" | "per_booking" | null;
 }
 
 export interface Wallet {

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -41,6 +41,8 @@ export function getPublicServerClient(): SupabaseClient<Database> {
   });
 }
 
+export const getPublicClient = getPublicServerClient;
+
 /**
  * Server client (RSC/Route Handlers) with cookie bridging.
  * Use this for authenticated server reads/writes with the user's session.

--- a/lib/validation/booking.ts
+++ b/lib/validation/booking.ts
@@ -20,3 +20,30 @@ export const confirmBookingSchema = z.object({
 });
 
 export type ConfirmBookingInput = z.infer<typeof confirmBookingSchema>;
+
+export const rescheduleBookingSchema = z.object({
+  bookingId: z.string().uuid(),
+  providerId: z.string().uuid(),
+  newStartAt: z.string().datetime(),
+  chargeCustomerFee: z.boolean().optional(),
+  note: z.string().max(500).optional(),
+});
+
+export type RescheduleBookingInput = z.infer<typeof rescheduleBookingSchema>;
+
+export const cancelBookingSchema = z.object({
+  bookingId: z.string().uuid(),
+  providerId: z.string().uuid(),
+  reason: z.string().max(500).optional(),
+  cancelledBy: z.enum(["provider", "customer"]).optional(),
+});
+
+export type CancelBookingInput = z.infer<typeof cancelBookingSchema>;
+
+export const checkAvailabilitySchema = z.object({
+  providerHandle: z.string().min(2),
+  serviceId: z.string().uuid(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
+export type CheckAvailabilityInput = z.infer<typeof checkAvailabilitySchema>;

--- a/lib/validation/wallet.ts
+++ b/lib/validation/wallet.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const walletTopupSchema = z.object({
+  credits: z.number().int().min(1).max(100),
+});
+
+export type WalletTopupInput = z.infer<typeof walletTopupSchema>;

--- a/supabase/migrations/0002_add_booking_pay_mode.sql
+++ b/supabase/migrations/0002_add_booking_pay_mode.sql
@@ -1,0 +1,2 @@
+alter table public.bookings
+  add column if not exists pay_mode text check (pay_mode in ('credit','per_booking'));

--- a/supabase/migrations/0003_add_reschedule_cancel_policy.sql
+++ b/supabase/migrations/0003_add_reschedule_cancel_policy.sql
@@ -1,0 +1,3 @@
+alter table public.providers
+  add column if not exists reschedule_fee_cents integer not null default 0,
+  add column if not exists late_cancel_hours integer not null default 12;

--- a/tests/booking-policy.test.ts
+++ b/tests/booking-policy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { evaluateCancellationPolicy } from "@/lib/domain/booking-policy";
+
+describe("evaluateCancellationPolicy", () => {
+  it("allows refunds when cancelling before the cutoff", () => {
+    const now = new Date("2024-03-01T08:00:00Z");
+    const startAt = new Date("2024-03-02T08:00:00Z");
+
+    const result = evaluateCancellationPolicy({
+      bookingStartAt: startAt.toISOString(),
+      lateCancelHours: 12,
+      now,
+    });
+
+    expect(result.refundEligible).toBe(true);
+    expect(result.isLate).toBe(false);
+  });
+
+  it("flags late cancellations inside the cutoff", () => {
+    const now = new Date("2024-03-01T20:00:00Z");
+    const startAt = new Date("2024-03-02T08:00:00Z");
+
+    const result = evaluateCancellationPolicy({
+      bookingStartAt: startAt.toISOString(),
+      lateCancelHours: 12,
+      now,
+    });
+
+    expect(result.refundEligible).toBe(false);
+    expect(result.isLate).toBe(true);
+  });
+});

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseNotificationPayload,
+  renderEmailTemplate,
+  renderWhatsAppTemplate,
+} from "@/lib/domain/notifications";
+
+describe("notification templates", () => {
+  it("parses and renders booking pending notifications", () => {
+    const payload = {
+      type: "booking_customer_pending" as const,
+      bookingId: "11111111-1111-1111-1111-111111111111",
+      providerHandle: "trim-spot",
+      providerName: "Trim Spot",
+      serviceName: "Haircut",
+      startAt: "2024-05-10T14:00:00.000Z",
+      customerName: "Alex",
+    };
+
+    const parsed = parseNotificationPayload(payload);
+    expect(parsed).not.toBeNull();
+
+    const email = renderEmailTemplate(parsed!);
+    expect(email.subject).toContain("Haircut");
+    expect(email.body).toContain("Trim Spot");
+
+    const whatsapp = renderWhatsAppTemplate(parsed!);
+    expect(whatsapp).toContain("Trim Spot");
+    expect(whatsapp).toContain("Haircut");
+  });
+
+  it("builds confirmation templates with customer name", () => {
+    const payload = {
+      type: "booking_customer_confirmed" as const,
+      bookingId: "11111111-1111-1111-1111-111111111112",
+      providerName: "Glow Nails",
+      serviceName: "Manicure",
+      startAt: "2024-05-10T16:00:00.000Z",
+      customerName: "Sam",
+    };
+
+    const parsed = parseNotificationPayload(payload);
+    expect(parsed).not.toBeNull();
+
+    const email = renderEmailTemplate(parsed!);
+    expect(email.subject).toContain("Glow Nails");
+    expect(email.body).toContain("Sam");
+
+    const whatsapp = renderWhatsAppTemplate(parsed!);
+    expect(whatsapp).toContain("Glow Nails");
+    expect(whatsapp).toContain("Manicure");
+  });
+
+  it("renders provider low credit alerts", () => {
+    const payload = {
+      type: "provider_low_credits_warning" as const,
+      providerName: "Fresh Cuts",
+      creditsRemaining: 1,
+    };
+
+    const parsed = parseNotificationPayload(payload);
+    expect(parsed).not.toBeNull();
+
+    const email = renderEmailTemplate(parsed!);
+    expect(email.subject).toContain("1 credit");
+    expect(email.body).toContain("Fresh Cuts");
+
+    const whatsapp = renderWhatsAppTemplate(parsed!);
+    expect(whatsapp).toContain("1");
+    expect(whatsapp).toContain("Fresh Cuts");
+  });
+
+  it("rejects invalid payloads", () => {
+    expect(parseNotificationPayload({ type: "unknown" })).toBeNull();
+  });
+});

--- a/tests/public-booking-widget.test.ts
+++ b/tests/public-booking-widget.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { pickFirstOpenDate } from "@/components/public-booking-widget";
+import type { AvailabilityRule, BlackoutDate } from "@/lib/domain/types";
+
+const baseRules: AvailabilityRule[] = [
+  { id: "r1", providerId: "p1", dow: 2, startTime: "09:00", endTime: "17:00" },
+  { id: "r2", providerId: "p1", dow: 3, startTime: "09:00", endTime: "17:00" },
+];
+
+const baseBlackouts: BlackoutDate[] = [];
+
+describe("pickFirstOpenDate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("selects the next day with availability when the first is blacked out", () => {
+    const blackoutDates: BlackoutDate[] = [{ id: "b1", providerId: "p1", day: "2024-01-02", reason: "Holiday" }];
+
+    const result = pickFirstOpenDate(baseRules, blackoutDates);
+
+    expect(result).toBe("2024-01-03");
+  });
+
+  it("falls back to today if no matching availability exists", () => {
+    const closedRules: AvailabilityRule[] = [
+      { id: "r3", providerId: "p1", dow: 0, startTime: "09:00", endTime: "17:00" },
+    ];
+
+    const result = pickFirstOpenDate(closedRules, baseBlackouts);
+
+    expect(result).toBe("2024-01-01");
+  });
+});

--- a/tests/reporting.test.ts
+++ b/tests/reporting.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { calculateConversionRate } from "@/lib/domain/reporting";
+
+describe("calculateConversionRate", () => {
+  it("returns 0 when there are no bookings", () => {
+    expect(calculateConversionRate(0, 0)).toBe(0);
+    expect(calculateConversionRate(0, 5)).toBe(0);
+  });
+
+  it("returns a whole number percentage when evenly divisible", () => {
+    expect(calculateConversionRate(5, 10)).toBe(50);
+  });
+
+  it("rounds to one decimal place for fractional values", () => {
+    expect(calculateConversionRate(3, 7)).toBeCloseTo(42.9, 5);
+    expect(calculateConversionRate(2, 3)).toBeCloseTo(66.7, 5);
+  });
+});

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { confirmBookingHappyPath, consumeCreditForBooking } from "@/lib/domain/wallet";
+import {
+  addCreditsToWallet,
+  confirmBookingHappyPath,
+  consumeCreditForBooking,
+  refundCreditForCancellation,
+} from "@/lib/domain/wallet";
 import type { Booking, Wallet } from "@/lib/domain/types";
 
 const baseWallet: Wallet = {
@@ -39,6 +44,43 @@ describe("consumeCreditForBooking", () => {
   });
 });
 
+describe("addCreditsToWallet", () => {
+  it("adds credits and records a topup ledger entry", () => {
+    const { wallet, ledgerEntry } = addCreditsToWallet({ ...baseWallet, balanceCredits: 1 }, 3, new Date("2024-01-01T00:00:00Z"));
+
+    expect(wallet.balanceCredits).toBe(4);
+    expect(ledgerEntry).toMatchObject({
+      walletId: baseWallet.id,
+      changeCredits: 3,
+      description: "Top up 3 credits",
+    });
+  });
+
+  it("rejects invalid credit amounts", () => {
+    expect(() => addCreditsToWallet(baseWallet, 0)).toThrowError("INVALID_TOPUP_CREDITS");
+    expect(() => addCreditsToWallet(baseWallet, -2)).toThrowError("INVALID_TOPUP_CREDITS");
+    expect(() => addCreditsToWallet(baseWallet, 1.5)).toThrowError("INVALID_TOPUP_CREDITS");
+  });
+});
+
+describe("refundCreditForCancellation", () => {
+  it("returns a credit to the wallet with a ledger record", () => {
+    const { wallet, ledgerEntry } = refundCreditForCancellation(
+      { ...baseWallet, balanceCredits: 0 },
+      baseBooking,
+      new Date("2024-02-01T00:00:00Z"),
+    );
+
+    expect(wallet.balanceCredits).toBe(1);
+    expect(ledgerEntry).toMatchObject({
+      walletId: baseWallet.id,
+      bookingId: baseBooking.id,
+      changeCredits: 1,
+      description: "Credit refunded after cancellation",
+    });
+  });
+});
+
 describe("confirmBookingHappyPath", () => {
   it("consumes a credit when wallet has balance", async () => {
     const result = await confirmBookingHappyPath({
@@ -46,7 +88,6 @@ describe("confirmBookingHappyPath", () => {
       booking: baseBooking,
       paymentIntentProvider: {
         createPerBookingIntent: vi.fn().mockResolvedValue({ checkoutUrl: "", reference: "" }),
-        createPerBookingIntent: vi.fn(),
       },
       bookingAmountCents: 5000,
     });
@@ -61,7 +102,6 @@ describe("confirmBookingHappyPath", () => {
       createPerBookingIntent: vi
         .fn()
         .mockResolvedValue({ checkoutUrl: "https://mockpay.local/checkout", reference: "mockpay_booking-1" }),
-      createPerBookingIntent: vi.fn().mockResolvedValue({ checkoutUrl: "https://mockpay.local/checkout" }),
     };
 
     const result = await confirmBookingHappyPath({

--- a/types/database.ts
+++ b/types/database.ts
@@ -39,6 +39,8 @@ export type Database = {
           bio: string | null;
           currency: string;
           payout_meta: Json | null;
+          reschedule_fee_cents: number;
+          late_cancel_hours: number;
           created_at: string;
         };
         Insert: {
@@ -49,6 +51,8 @@ export type Database = {
           bio?: string | null;
           currency?: string;
           payout_meta?: Json | null;
+          reschedule_fee_cents?: number;
+          late_cancel_hours?: number;
           created_at?: string;
         };
         Update: {
@@ -57,6 +61,8 @@ export type Database = {
           bio?: string | null;
           currency?: string;
           payout_meta?: Json | null;
+          reschedule_fee_cents?: number;
+          late_cancel_hours?: number;
         };
       };
       customers: {
@@ -164,6 +170,7 @@ export type Database = {
           start_at: string;
           end_at: string | null;
           status: "pending" | "confirmed" | "cancelled" | "completed" | "no_show";
+          pay_mode: "credit" | "per_booking" | null;
           notes: string | null;
           created_at: string;
           updated_at: string;
@@ -176,6 +183,7 @@ export type Database = {
           start_at: string;
           end_at?: string | null;
           status?: "pending" | "confirmed" | "cancelled" | "completed" | "no_show";
+          pay_mode?: "credit" | "per_booking" | null;
           notes?: string | null;
           created_at?: string;
           updated_at?: string;
@@ -184,6 +192,7 @@ export type Database = {
           start_at?: string;
           end_at?: string | null;
           status?: "pending" | "confirmed" | "cancelled" | "completed" | "no_show";
+          pay_mode?: "credit" | "per_booking" | null;
           notes?: string | null;
           updated_at?: string;
         };


### PR DESCRIPTION
## Summary
- add a provider dashboard page that surfaces key booking metrics, conversion health, and the next five confirmed appointments
- add reporting helpers that query Supabase for booking counts and upcoming bookings plus a reusable conversion rate calculator
- cover the conversion rate helper with unit tests

## Testing
- npm run lint
- npm run typecheck
- npm run test *(fails: npm optional dependency bug prevents installing `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_68d42db403a88326b9b2bdc2e6fd30cd