### PR TITLE
Sanitize OTP codes before verifying email login

### DIFF
--- a/app/api/auth/verify-otp/route.ts
+++ b/app/api/auth/verify-otp/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { getRouteHandlerClient } from "@/lib/supabase/server";
+import { sanitizeOtpCode } from "@/lib/utils/sanitize";
 
 const verifySchema = z.object({
   email: z.string().email("Enter a valid email address"),
-  token: z.string().min(6).max(6),
+  token: z.preprocess(
+    (value) => sanitizeOtpCode(typeof value === "string" ? value : ""),
+    z.string().length(6, "Enter the 6-digit code from your email."),
+  ),
 });
 
 export async function POST(request: Request) {

--- a/components/auth/email-otp-form.tsx
+++ b/components/auth/email-otp-form.tsx
@@ -2,6 +2,8 @@
 
 import { useState, type FormEvent } from "react";
 
+import { sanitizeOtpCode } from "@/lib/utils/sanitize";
+
 interface EmailOtpFormState {
   step: "request" | "verify";
   message?: string;
@@ -48,9 +50,9 @@ export function EmailOtpForm() {
   async function verifyOtp(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
-    const token = String(formData.get("token") ?? "").trim();
+    const token = sanitizeOtpCode(String(formData.get("token") ?? ""));
 
-    if (!token) {
+    if (token.length !== 6) {
       setState((prev) => ({ ...prev, error: "Enter the 6-digit code from your email." }));
       return;
     }


### PR DESCRIPTION
## Summary
- sanitize the OTP value on the email login form before verifying so pasted codes with spaces are cleaned
- normalize the OTP token server-side in the verify route to accept sanitized 6-digit codes before calling Supabase

## Testing
- npm test *(fails: missing optional rollup binary in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a43512b483269cb49a629beee5ae